### PR TITLE
Allow keywords in field accessors

### DIFF
--- a/jackson-jq/src/main/javacc/json-query.jj
+++ b/jackson-jq/src/main/javacc/json-query.jj
@@ -89,7 +89,18 @@ TOKEN: {
 }
 
 TOKEN: { <SEMICOLON: ";"> }
-TOKEN: { <DOT: "."> }
+
+// We have to be careful about spaces after ".". jq-1.4 or newer does not allow spaces between "." and <identifier> in field accessors.
+// For example, '. foo' is an error while '.foo' is not. This distinction is important to parse "if . then . else empty end".
+// IDENTIFIER_AFTER_DOT and OTHERWISE_AFTER_DOT should not be re-ordered. The order matters.
+TOKEN: { <DOT: "."> : STATE_DOT }
+<STATE_DOT> TOKEN: {
+	<IDENTIFIER_AFTER_DOT: <IDENTIFIER>> : DEFAULT
+}
+<STATE_DOT> MORE: {
+	<OTHERWISE_AFTER_DOT: ""> : DEFAULT
+}
+
 TOKEN: { <RECURSION: ".."> }
 
 TOKEN: { <OPEN_BRACKET: "["> }
@@ -784,7 +795,7 @@ JsonQuery IdentifierFieldAccessor(JsonQuery obj):
 }
 {
 	<DOT>
-	identifier = <IDENTIFIER>
+	identifier = <IDENTIFIER_AFTER_DOT>
 	(
 		<QUESTION>
 		{ permissive = true; }

--- a/jackson-jq/src/test/java/net/thisptr/jackson/jq/internal/javacc/JsonQueryParserTest.java
+++ b/jackson-jq/src/test/java/net/thisptr/jackson/jq/internal/javacc/JsonQueryParserTest.java
@@ -36,11 +36,15 @@ public class JsonQueryParserTest {
 	public void testSupportedQueries() throws IOException, ParseException, TokenMgrError {
 		final List<String> loadQueries = loadQueries("compiler-test-ok.txt");
 		for (int i = 0; i < loadQueries.size(); i++) {
-			final JsonQuery jq = JsonQueryParser.compile(loadQueries.get(i));
-			if (jq == null) {
-				System.out.printf("%d: ---%n", i);
-			} else {
-				System.out.printf("%d: %s%n", i, jq);
+			try {
+				final JsonQuery jq = JsonQueryParser.compile(loadQueries.get(i));
+				if (jq == null) {
+					System.out.printf("%d: ---%n", i);
+				} else {
+					System.out.printf("%d: %s%n", i, jq);
+				}
+			} catch (final Throwable th) {
+				throw new RuntimeException("Failed to compile \"" + loadQueries.get(i) + "\"", th);
 			}
 		}
 	}

--- a/jackson-jq/src/test/resources/jq-test-extra-ok.json
+++ b/jackson-jq/src/test/resources/jq-test-extra-ok.json
@@ -712,5 +712,12 @@
 	{
 		"q": "try ((error(\"foo\"))?) catch .",
 		"out": []
+	},
+	{
+		"q": ".foreach",
+		"in": {"foreach": 10},
+		"out": [
+			10
+		]
 	}
 ]


### PR DESCRIPTION
Fixes #20 

To interpret expressions such as `if . then . else empty end` correctly, it is now considered an error to include spaces between `.` and an identifier in a field accessor (e.g. `. foo`). While the new behavior is in line with jq, this is a backward incompatible change for jackson-jq users.