### PR TITLE
Added date functions currently supported in jq

### DIFF
--- a/jackson-jq-extra/src/main/java/net/thisptr/jackson/jq/extra/functions/FromIso8601Function.java
+++ b/jackson-jq-extra/src/main/java/net/thisptr/jackson/jq/extra/functions/FromIso8601Function.java
@@ -1,0 +1,56 @@
+package net.thisptr.jackson.jq.extra.functions;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.JsonNodeType;
+import com.fasterxml.jackson.databind.node.LongNode;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.List;
+import net.thisptr.jackson.jq.Function;
+import net.thisptr.jackson.jq.JsonQuery;
+import net.thisptr.jackson.jq.Scope;
+import net.thisptr.jackson.jq.exception.JsonQueryException;
+import net.thisptr.jackson.jq.internal.BuiltinFunction;
+import net.thisptr.jackson.jq.internal.misc.Preconditions;
+
+/**
+ * Excerpt from jq documentation:
+ * The `fromdateiso8601` builtin parses datetimes in the ISO 8601 format to a number of seconds since the Unix epoch
+ *(1970-01-01T00:00:00Z).
+ *
+ * This implementation has the default behaviour as described above and an additional
+ * variant that accepts zoneHours as argument in case the timezone being matched is different than current timezone.
+ */
+@BuiltinFunction({ "fromdateiso8601/0", "fromdateiso8601/1"})
+public class FromIso8601Function implements Function {
+
+  @Override
+  public List<JsonNode> apply(final Scope scope, final List<JsonQuery> args, final JsonNode in) throws JsonQueryException {
+    Preconditions.checkInputType("fromdateiso8601", in, JsonNodeType.STRING);
+
+    final List<JsonNode> out = new ArrayList<>();
+
+    try{
+      LocalDateTime date = LocalDateTime.parse(in.asText(), DateTimeFormatter.ISO_DATE_TIME);
+      Instant is = null;
+
+      if(args.size() == 1) {
+        for (final JsonNode offset : args.get(0).apply(in)) {
+          if (!offset.canConvertToInt()) throw JsonQueryException.format("Offset must be an integer");
+            is = date.toInstant(ZoneOffset.ofHours(offset.intValue()));
+        }
+      } else {
+        is = date.toInstant(ZoneOffset.UTC);
+      }
+      out.add(new LongNode(is.toEpochMilli()));
+
+    } catch (Exception e) {
+      throw new JsonQueryException(e);
+    }
+    return out;
+  }
+
+}

--- a/jackson-jq-extra/src/main/java/net/thisptr/jackson/jq/extra/functions/NowFunction.java
+++ b/jackson-jq-extra/src/main/java/net/thisptr/jackson/jq/extra/functions/NowFunction.java
@@ -1,0 +1,20 @@
+package net.thisptr.jackson.jq.extra.functions;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.LongNode;
+import java.time.Instant;
+import java.util.Collections;
+import java.util.List;
+import net.thisptr.jackson.jq.Function;
+import net.thisptr.jackson.jq.JsonQuery;
+import net.thisptr.jackson.jq.Scope;
+import net.thisptr.jackson.jq.exception.JsonQueryException;
+import net.thisptr.jackson.jq.internal.BuiltinFunction;
+
+@BuiltinFunction({ "now/0" })
+public class NowFunction implements Function {
+  @Override
+  public List<JsonNode> apply(final Scope scope, final List<JsonQuery> args, final JsonNode in) throws JsonQueryException {
+    return Collections.<JsonNode> singletonList(new LongNode(Instant.now().toEpochMilli()));
+  }
+}

--- a/jackson-jq-extra/src/main/java/net/thisptr/jackson/jq/extra/functions/ToIso8601Function.java
+++ b/jackson-jq-extra/src/main/java/net/thisptr/jackson/jq/extra/functions/ToIso8601Function.java
@@ -1,0 +1,51 @@
+package net.thisptr.jackson.jq.extra.functions;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.JsonNodeType;
+import com.fasterxml.jackson.databind.node.TextNode;
+import java.text.SimpleDateFormat;
+import java.time.Instant;
+import java.util.Collections;
+import java.util.Date;
+import java.util.List;
+import java.util.TimeZone;
+import net.thisptr.jackson.jq.Function;
+import net.thisptr.jackson.jq.JsonQuery;
+import net.thisptr.jackson.jq.Scope;
+import net.thisptr.jackson.jq.exception.JsonQueryException;
+import net.thisptr.jackson.jq.internal.BuiltinFunction;
+import net.thisptr.jackson.jq.internal.misc.Preconditions;
+
+/**
+ * Excerpt from JQ documentation:
+ * jq provides some basic date handling functionality, with some high-level and low-level builtins.  In all cases these
+ * builtins deal exclusively with time in UTC.
+
+  The `fromdateiso8601` builtin parses datetimes in the ISO 8601 format to a number of seconds since the Unix epoch
+ (1970-01-01T00:00:00Z).  The `todateiso8601` builtin does the inverse.
+
+ * This implementation has the default behaviour as described above
+ */
+@BuiltinFunction({ "todateiso8601/0"})
+public class ToIso8601Function implements Function {
+
+  @Override
+  public List<JsonNode> apply(final Scope scope, final List<JsonQuery> args, final JsonNode in) throws JsonQueryException {
+    Preconditions.checkInputType("todateiso8601", in, JsonNodeType.NUMBER);
+    try{
+      String formattedDate = getFormattedDate(in.asLong());
+      return Collections.<JsonNode> singletonList(new TextNode(formattedDate));
+    } catch (Exception e) {
+      e.printStackTrace();
+      throw new JsonQueryException(e);
+    }
+  }
+
+  private static String getFormattedDate(long timeInMillis) {
+    final SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssXXX");
+    sdf.setTimeZone(TimeZone.getTimeZone("UTC"));
+    Instant instant = Instant.ofEpochMilli(timeInMillis);
+    return sdf.format(Date.from(instant));
+  }
+
+}

--- a/jackson-jq-extra/src/main/resources/META-INF/services/net.thisptr.jackson.jq.Function
+++ b/jackson-jq-extra/src/main/resources/META-INF/services/net.thisptr.jackson.jq.Function
@@ -6,3 +6,6 @@ net.thisptr.jackson.jq.extra.functions.TimestampFunction
 net.thisptr.jackson.jq.extra.functions.UriDecodeFunction
 net.thisptr.jackson.jq.extra.functions.UriParseFunction
 net.thisptr.jackson.jq.extra.functions.Uuid4Function
+net.thisptr.jackson.jq.extra.functions.ToIso8601Function
+net.thisptr.jackson.jq.extra.functions.FromIso8601Function
+net.thisptr.jackson.jq.extra.functions.NowFunction

--- a/jackson-jq-extra/src/test/java/net/thisptr/jackson/jq/extra/functions/FromIso8601FunctionTest.java
+++ b/jackson-jq-extra/src/test/java/net/thisptr/jackson/jq/extra/functions/FromIso8601FunctionTest.java
@@ -1,0 +1,83 @@
+package net.thisptr.jackson.jq.extra.functions;
+
+import static org.junit.Assert.assertEquals;
+
+import com.fasterxml.jackson.databind.node.DoubleNode;
+import com.fasterxml.jackson.databind.node.IntNode;
+import com.fasterxml.jackson.databind.node.TextNode;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import net.thisptr.jackson.jq.JsonQuery;
+import net.thisptr.jackson.jq.Scope;
+import net.thisptr.jackson.jq.exception.IllegalJsonInputException;
+import net.thisptr.jackson.jq.exception.JsonQueryException;
+import org.junit.Test;
+
+public class FromIso8601FunctionTest {
+
+
+  @Test(expected = IllegalJsonInputException.class)
+  public void failOnInvalidInputAsInt() throws JsonQueryException {
+    new FromIso8601Function().apply(new Scope(), Collections.<JsonQuery> emptyList(), new IntNode(12));
+  }
+
+  @Test(expected = IllegalJsonInputException.class)
+  public void failOnInvalidInputAsDouble() throws JsonQueryException {
+    new FromIso8601Function().apply(new Scope(), Collections.<JsonQuery> emptyList(), new DoubleNode(123241324.1234));
+  }
+
+
+  @Test
+  public void validInputs() throws JsonQueryException {
+
+    assertEquals(expectedTimeInMillis("1970-01-01T00:00:00Z"),
+        fromIso8601Function("1970-01-01T00:00:00Z"));
+
+    assertEquals(expectedTimeInMillis("2011-12-03T10:15:30-07:00"),
+        fromIso8601Function("2011-12-03T10:15:30-07:00"));
+
+    assertEquals(expectedTimeInMillis("2018-12-03T10:15:30+07:00"),
+        fromIso8601Function("2018-12-03T10:15:30+07:00"));
+
+  }
+
+  @Test
+  public void validInputsWithOffset() throws JsonQueryException {
+
+    assertEquals(expectedTimeInMillisWithZoneAdjustment("1970-01-01T00:00:00Z", 0),
+        fromIso8601Function("1970-01-01T00:00:00Z", 0));
+
+   assertEquals(expectedTimeInMillisWithZoneAdjustment("2011-12-03T10:15:30+00:00", -7),
+        fromIso8601Function("2011-12-03T10:15:30+07:00", -7));
+
+    assertEquals(expectedTimeInMillisWithZoneAdjustment("2018-12-03T10:15:30+17:00", 10),
+        fromIso8601Function("2018-12-03T10:15:30+07:00", 10));
+
+  }
+
+  private long fromIso8601Function(String stringDate) throws JsonQueryException {
+    return new FromIso8601Function().apply(new Scope(), Collections.<JsonQuery> emptyList(), new TextNode(stringDate)).get(0).asLong();
+  }
+
+  private long fromIso8601Function(String stringDate, int offset) throws JsonQueryException {
+    final JsonQuery q = JsonQuery.compile("("+ offset + ")");
+    List<JsonQuery> list = new ArrayList<>();
+    list.add(q);
+    return new FromIso8601Function().apply(new Scope(), list, new TextNode(stringDate)).get(0).asLong();
+  }
+
+  private static long expectedTimeInMillis(String expectedInputTimeAsString) {
+    LocalDateTime expected = LocalDateTime.parse(expectedInputTimeAsString, DateTimeFormatter.ISO_DATE_TIME);
+    return expected.toEpochSecond(ZoneOffset.UTC) * 1000;
+  }
+
+  private static long expectedTimeInMillisWithZoneAdjustment(String expectedInputTimeAsString, int zoneHoursOffset) {
+    LocalDateTime expected = LocalDateTime.parse(expectedInputTimeAsString, DateTimeFormatter.ISO_DATE_TIME);
+    return expected.toEpochSecond(ZoneOffset.ofHours(zoneHoursOffset)) * 1000;
+  }
+
+}

--- a/jackson-jq-extra/src/test/java/net/thisptr/jackson/jq/extra/functions/NowFunctionTest.java
+++ b/jackson-jq-extra/src/test/java/net/thisptr/jackson/jq/extra/functions/NowFunctionTest.java
@@ -1,0 +1,34 @@
+package net.thisptr.jackson.jq.extra.functions;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import java.time.Instant;
+import java.util.Collections;
+import java.util.Date;
+import java.util.List;
+import net.thisptr.jackson.jq.JsonQuery;
+import net.thisptr.jackson.jq.Scope;
+import net.thisptr.jackson.jq.exception.JsonQueryException;
+import org.junit.Test;
+
+public class NowFunctionTest {
+
+  @Test
+  public void testIfTimeIsInMillisEpoch() throws JsonQueryException {
+    List<JsonNode> output = new NowFunction().apply(new Scope(), Collections.<JsonQuery> emptyList(), null);
+    assertEquals(1 , output.size());
+    assertEpochTimeStampIsValid(output.get(0).asLong());
+  }
+
+  private void assertEpochTimeStampIsValid(long timeInMillis) {
+    Instant instant = Instant.ofEpochMilli(timeInMillis);
+    Date date = Date.from(instant);
+    //verify date is parseable
+    assertNotNull(date);
+    assertTrue(Date.from(Instant.now()).compareTo(date) != -1);
+
+  }
+}

--- a/jackson-jq-extra/src/test/java/net/thisptr/jackson/jq/extra/functions/ToIso8601FunctionTest.java
+++ b/jackson-jq-extra/src/test/java/net/thisptr/jackson/jq/extra/functions/ToIso8601FunctionTest.java
@@ -1,0 +1,32 @@
+package net.thisptr.jackson.jq.extra.functions;
+
+import static org.junit.Assert.assertEquals;
+
+import com.fasterxml.jackson.databind.node.LongNode;
+import com.fasterxml.jackson.databind.node.TextNode;
+import java.util.Collections;
+import net.thisptr.jackson.jq.JsonQuery;
+import net.thisptr.jackson.jq.Scope;
+import net.thisptr.jackson.jq.exception.IllegalJsonInputException;
+import net.thisptr.jackson.jq.exception.JsonQueryException;
+import org.junit.Test;
+
+public class ToIso8601FunctionTest {
+
+
+  @Test(expected = IllegalJsonInputException.class)
+  public void failOnInvalidInputAsText() throws JsonQueryException {
+    new ToIso8601Function().apply(new Scope(), Collections.<JsonQuery> emptyList(), new TextNode("some-text"));
+  }
+
+  @Test
+  public void validInputs() throws JsonQueryException {
+    assertEquals("1970-01-17T11:59:59Z", toIso8601Function(1425599507l));
+    assertEquals("2011-12-03T10:15:30Z", toIso8601Function(1322907330000l));
+  }
+
+  private String toIso8601Function(long timeinMillis) throws JsonQueryException {
+    return new ToIso8601Function().apply(new Scope(), Collections.<JsonQuery> emptyList(), new LongNode(timeinMillis)).get(0).asText();
+  }
+
+}


### PR DESCRIPTION
This PR introduces support for date functions in jackson-jq (These date functions are already available in jq)
Reference: https://github.com/stedolan/jq/blob/9c4238c2f6ba9bd19974bcdf3ceecded82742d89/docs/content/3.manual/v1.5/manual.yml#L1699

 - now
 - fromdateiso8601
 - todateiso8601