### PR TITLE
Optimize ArrayList allocations

### DIFF
--- a/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/tree/fieldaccess/FieldAccess.java
+++ b/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/tree/fieldaccess/FieldAccess.java
@@ -1,6 +1,7 @@
 package net.thisptr.jackson.jq.internal.tree.fieldaccess;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 import net.thisptr.jackson.jq.JsonQuery;
@@ -36,11 +37,19 @@ public abstract class FieldAccess extends JsonQuery {
 
 	@Override
 	public List<JsonNode> apply(final Scope scope, final JsonNode in) throws JsonQueryException {
-		final List<JsonNode> out = new ArrayList<>();
 		final ResolvedFieldAccess resolvedFieldAccess = resolveFieldAccess(scope, in);
-		for (final JsonNode i : target.apply(scope, in))
-			out.addAll(resolvedFieldAccess.apply(scope, i));
-		return out;
+		final List<JsonNode> nodes = target.apply(scope, in);
+		switch (nodes.size()) {
+			case 0:
+				return Collections.emptyList();
+			case 1:
+				return resolvedFieldAccess.apply(scope, nodes.get(0));
+			default:
+				final List<JsonNode> out = new ArrayList<>(nodes.size());
+				for (final JsonNode i : nodes)
+					out.addAll(resolvedFieldAccess.apply(scope, i));
+				return out;
+		}
 	}
 
 	public abstract ResolvedFieldAccess resolveFieldAccess(final Scope scope, final JsonNode in) throws JsonQueryException;

--- a/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/tree/fieldaccess/resolved/ResolvedAllFieldAccess.java
+++ b/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/tree/fieldaccess/resolved/ResolvedAllFieldAccess.java
@@ -1,6 +1,7 @@
 package net.thisptr.jackson.jq.internal.tree.fieldaccess.resolved;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map.Entry;
@@ -17,22 +18,44 @@ public class ResolvedAllFieldAccess extends ResolvedFieldAccess {
 
 	@Override
 	public List<JsonNode> apply(Scope scope, JsonNode in) throws JsonQueryException {
-		final List<JsonNode> out = new ArrayList<>();
+
+		final int size = in.size();
+
 		if (in.isNull()) {
 			if (!permissive)
 				throw new JsonQueryException("Cannot iterate over null");
 		} else if (in.isArray()) {
-			final Iterator<JsonNode> values = in.iterator();
-			while (values.hasNext())
-				out.add(values.next());
+			switch (in.size()) {
+				case 0:
+					break;
+				case 1:
+					return Collections.singletonList(in.elements().next());
+				default:
+					final List<JsonNode> out = new ArrayList<>(size);
+					for (JsonNode child : in) {
+						out.add(child);
+					}
+					return out;
+			}
 		} else if (in.isObject()) {
-			final Iterator<Entry<String, JsonNode>> fields = in.fields();
-			while (fields.hasNext())
-				out.add(fields.next().getValue());
+			switch (in.size()) {
+				case 0:
+					break;
+				case 1:
+					return Collections.singletonList(in.fields().next().getValue());
+				default:
+					final List<JsonNode> out = new ArrayList<>(size);
+					final Iterator<Entry<String, JsonNode>> fields = in.fields();
+					while (fields.hasNext()) {
+						out.add(fields.next().getValue());
+					}
+					return out;
+			}
 		} else {
 			if (!permissive)
 				throw JsonQueryException.format("Cannot iterate over %s", in.getNodeType());
 		}
-		return out;
+
+		return Collections.emptyList();
 	}
 }

--- a/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/tree/fieldaccess/resolved/ResolvedIndexFieldAccess.java
+++ b/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/tree/fieldaccess/resolved/ResolvedIndexFieldAccess.java
@@ -20,23 +20,49 @@ public class ResolvedIndexFieldAccess extends ResolvedFieldAccess {
 
 	@Override
 	public List<JsonNode> apply(final Scope scope, final JsonNode in) throws JsonQueryException {
-		final List<JsonNode> out = new ArrayList<>();
-		for (final long _index : indices) {
-			if (in.isArray()) {
-				final long index = _index < 0 ? _index + in.size() : _index;
-				if (0 <= index && index < in.size()) {
-					out.add(in.get((int) index));
-				} else {
-					out.add(NullNode.getInstance());
-				}
-			} else if (in.isNull()) {
-				out.add(NullNode.getInstance());
-			} else {
-				if (!permissive)
-					throw JsonQueryException.format("Cannot index %s with number", in.getNodeType());
+
+		int size = indices.size();
+
+		if (in.isArray()) {
+			switch (size) {
+				case 0:
+					break;
+				case 1:
+					return Collections.singletonList(apply0(in, indices.get(0)));
+				default:
+					final List<JsonNode> out = new ArrayList<>(size);
+					for (final long _index : indices) {
+						out.add(apply0(in, _index));
+					}
+					return out;
 			}
+		} else if (in.isNull()) {
+			switch (size) {
+				case 0:
+					break;
+				case 1:
+					return Collections.singletonList(NullNode.getInstance());
+				default:
+					final List<JsonNode> out = new ArrayList<>(size);
+					for (int i = 0; i < size; i++) {
+						out.add(NullNode.getInstance());
+					}
+					return out;
+			}
+		} else {
+			if (!permissive)
+				throw JsonQueryException.format("Cannot index %s with number", in.getNodeType());
 		}
-		return out;
+		return Collections.emptyList();
+	}
+
+	private JsonNode apply0(final JsonNode in, long _index) {
+		final long index = _index < 0 ? _index + in.size() : _index;
+		if (0 <= index && index < in.size()) {
+			return in.get((int) index);
+		} else {
+			return NullNode.getInstance();
+		}
 	}
 
 	public List<Long> indices() {

--- a/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/tree/fieldaccess/resolved/ResolvedStringFieldAccess.java
+++ b/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/tree/fieldaccess/resolved/ResolvedStringFieldAccess.java
@@ -25,18 +25,35 @@ public class ResolvedStringFieldAccess extends ResolvedFieldAccess {
 
 	@Override
 	public List<JsonNode> apply(final Scope scope, final JsonNode in) throws JsonQueryException {
-		final List<JsonNode> out = new ArrayList<>();
-		for (final String key : keys) {
-			if (in.isNull()) {
-				out.add(NullNode.getInstance());
-			} else if (in.isObject()) {
-				final JsonNode n = in.get(key);
-				out.add(n == null ? NullNode.getInstance() : n);
+		if (keys.isEmpty()) {
+			return Collections.emptyList();
+		} else if (keys.size() == 1) {
+			JsonNode node = apply0(in, keys.get(0));
+			return node != null ? Collections.singletonList(node) : Collections.emptyList();
+		} else {
+			final List<JsonNode> out = new ArrayList<>(keys.size());
+			for (String key : keys) {
+				JsonNode node = apply0(in, key);
+				if (node != null) {
+					out.add(node);
+				}
+			}
+			return out;
+		}
+	}
+
+	private JsonNode apply0(final JsonNode in, final String key) throws JsonQueryException {
+		if (in.isNull()) {
+			return NullNode.getInstance();
+		} else if (in.isObject()) {
+			JsonNode n = in.get(key);
+			return n == null ? NullNode.getInstance() : n;
+		} else {
+			if (!permissive) {
+				throw new JsonQueryException(String.format("Cannot index %s with string \"%s\"", JsonNodeUtils.typeOf(in), key));
 			} else {
-				if (!permissive)
-					throw new JsonQueryException(String.format("Cannot index %s with string \"%s\"", JsonNodeUtils.typeOf(in), key));
+				return null;
 			}
 		}
-		return out;
 	}
 }


### PR DESCRIPTION
Motivation:

There are tons of places where jackson-jq allocates ArrayLists with default size (which is 10) while the target size is known. In some cases, we even already know that the target is a singleton, hence no need to allocate an ArrayList.

This is a waste of allocations.

Modifications:

Introduce fast paths in `FieldAccess`, `ResolvedAllFieldAccess`, `ResolvedIndexFieldAccess` and `ResolvedStringFieldAccess` for cases  where target collection is a singleton.

Result:

Less allocations, +20% throughput improvement on some of my internal benchmarks, eg when extracting one single field.