### PR TITLE
add base64d/0, originally appeared in jq-1.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ The following table (generated from jq-1.5 manual) lists all the features jq pro
 ※3) When the function with the same name is defined more than once in the same-level scope, jackson-jq uses the last one. E.g.
  - `def f: 1; def g: f; def f: 2; g` evaluates to 2 in jackson-jq, while jq evaluates it to 1.
 
-※4) `@html`, `@uri`, `@sh`, `@base64` are not implemented yet.
+※4) `@html`, `@uri`, `@sh` are not implemented yet.
 
 
 Additionally, test cases used in jackson-jq (from the jq unit tests) might be useful to know what kind of queries work or not work.

--- a/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/functions/AtBase64dFunction.java
+++ b/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/functions/AtBase64dFunction.java
@@ -1,0 +1,14 @@
+package net.thisptr.jackson.jq.internal.functions;
+
+import java.util.Base64;
+
+import net.thisptr.jackson.jq.exception.JsonQueryException;
+import net.thisptr.jackson.jq.internal.BuiltinFunction;
+
+@BuiltinFunction("@base64d/0")
+public class AtBase64dFunction extends AbstractAtFormattingFunction {
+	@Override
+	public String convert(final String text) throws JsonQueryException {
+		return new String(Base64.getDecoder().decode(text));
+	}
+}

--- a/jackson-jq/src/main/resources/META-INF/services/net.thisptr.jackson.jq.Function
+++ b/jackson-jq/src/main/resources/META-INF/services/net.thisptr.jackson.jq.Function
@@ -1,5 +1,6 @@
 net.thisptr.jackson.jq.Scope$DebugScopeFunction
 net.thisptr.jackson.jq.internal.functions.AtBase64Function
+net.thisptr.jackson.jq.internal.functions.AtBase64dFunction
 net.thisptr.jackson.jq.internal.functions.AtHtmlFunction
 net.thisptr.jackson.jq.internal.functions.AtShFunction
 net.thisptr.jackson.jq.internal.functions.AtUriFunction

--- a/jackson-jq/src/test/resources/jq-test-all-ok.json
+++ b/jackson-jq/src/test/resources/jq-test-all-ok.json
@@ -107,6 +107,13 @@
         "q": "@base64"
     },
     {
+        "in": "Zm/Ds2Jhcgo=",
+        "out": [
+            "fo\u00f3bar\n"
+        ],
+        "q": "@base64d"
+    },
+    {
         "in": "\u03bc",
         "out": [
             "%CE%BC"


### PR DESCRIPTION
This patch adds `@base64d` function, the inverse of `@base64`.
The input is decoded as specified by RFC 4648.   The decoded string must be UTF-8.