### PR TITLE
indices/1: fix infinite loop on empty needle text (fix #59)

### DIFF
--- a/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/functions/IndicesFunction.java
+++ b/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/functions/IndicesFunction.java
@@ -47,8 +47,10 @@ public class IndicesFunction implements Function {
 		if (needle.isTextual() && haystack.isTextual()) {
 			final String haystackText = haystack.asText();
 			final String needleText = needle.asText();
-			for (int index = haystackText.indexOf(needleText); index >= 0; index = haystackText.indexOf(needleText, index + 1))
-				result.add(index);
+			if (!needleText.isEmpty()) {
+				for (int index = haystackText.indexOf(needleText); index >= 0; index = haystackText.indexOf(needleText, index + 1))
+					result.add(index);
+			}
 		} else if (needle.isArray() && haystack.isArray()) {
 			if (needle.size() != 0) {
 				for (int i = 0; i < haystack.size(); ++i) {


### PR DESCRIPTION
This pull request fixes #59. The `needle` array checks non-empty but `needleText` didn't.