### PR TITLE
refactor: erefactor/AutoRefactor - Implicit default constructor rathe…

### DIFF
--- a/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/tree/ObjectConstruction.java
+++ b/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/tree/ObjectConstruction.java
@@ -18,8 +18,6 @@ import net.thisptr.jackson.jq.path.Path;
 public class ObjectConstruction implements Expression {
 	private final List<FieldConstruction> fields = new ArrayList<>();
 
-	public ObjectConstruction() {}
-
 	public void add(final FieldConstruction field) {
 		fields.add(field);
 	}


### PR DESCRIPTION
…r than written one

AutoRefactor cleanup 'ImplicitDefaultConstructorRatherThanWrittenOneCleanUp' applied by erefactor:

Remove single public constructor with no arguments, no annotation and
no code.

For AutoRefactor see https://github.com/JnRouvignac/AutoRefactor
For erefactor see https://github.com/cal101/erefactor