### PR TITLE
refactor: erefactor/AutoRefactor - String

### DIFF
--- a/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/tree/IdentifierKeyFieldConstruction.java
+++ b/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/tree/IdentifierKeyFieldConstruction.java
@@ -34,7 +34,7 @@ public class IdentifierKeyFieldConstruction implements FieldConstruction {
 		if (value == null) {
 			return key;
 		} else {
-			return key + ": " + value.toString();
+			return key + ": " + value;
 		}
 	}
 }

--- a/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/tree/JsonQueryKeyFieldConstruction.java
+++ b/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/tree/JsonQueryKeyFieldConstruction.java
@@ -27,7 +27,7 @@ public class JsonQueryKeyFieldConstruction implements FieldConstruction {
 
 	@Override
 	public String toString() {
-		final String result = "(" + key.toString() + ")";
+		final String result = "(" + key + ")";
 		return result + ": " + value;
 	}
 }

--- a/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/tree/NegativeExpression.java
+++ b/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/tree/NegativeExpression.java
@@ -28,6 +28,6 @@ public class NegativeExpression implements Expression {
 
 	@Override
 	public String toString() {
-		return "-(" + value.toString() + ")";
+		return "-(" + value + ")";
 	}
 }

--- a/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/tree/StringKeyFieldConstruction.java
+++ b/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/tree/StringKeyFieldConstruction.java
@@ -38,7 +38,7 @@ public class StringKeyFieldConstruction implements FieldConstruction {
 		if (value == null) {
 			return key.toString();
 		} else {
-			return key.toString() + ": " + value.toString();
+			return key + ": " + value;
 		}
 	}
 }

--- a/jackson-jq/src/test/java/net/thisptr/jackson/jq/test/evaluator/TrueJqEvaluator.java
+++ b/jackson-jq/src/test/java/net/thisptr/jackson/jq/test/evaluator/TrueJqEvaluator.java
@@ -29,7 +29,7 @@ public class TrueJqEvaluator implements Evaluator {
 	private static final ObjectMapper MAPPER = new ObjectMapper();
 
 	public static String executable(final Version version) {
-		return "jq-" + version.toString();
+		return "jq-" + version;
 	}
 
 	public static boolean hasJq(final Version version) {


### PR DESCRIPTION
AutoRefactor cleanup 'StringCleanUp' applied by erefactor:

Removes:
- calling String.toString() on a String instance,
- remove calls to String.toString() inside String concatenations,
- replace useless case shifts for equality by equalsIgnoreCase()
Refactors:
- usages of 'indexOf' and 'lastIndexOf' with single letter in string

For AutoRefactor see https://github.com/JnRouvignac/AutoRefactor
For erefactor see https://github.com/cal101/erefactor