### PR TITLE
env/0: remove @BuiltinFunction as an extra safeguard

### DIFF
--- a/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/functions/EnvFunction.java
+++ b/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/functions/EnvFunction.java
@@ -16,7 +16,8 @@ import net.thisptr.jackson.jq.path.Path;
 
 // For security reasons, env/0 should not be loaded by default.
 // @AutoService(Function.class)
-@BuiltinFunction("env/0")
+// 2022-06-29(eiiches): commented out @BuiltinFunction("env/0") to make sure some custom function loaders don't load `env/0` accidentally.
+// @BuiltinFunction("env/0")
 public class EnvFunction implements Function {
 	private static final ObjectMapper MAPPER = new ObjectMapper();
 


### PR DESCRIPTION
`env/0` is not loaded by default as long as the default builtin function loader is used. To make sure custom function loaders don't load `env/0` accidentally, this PR removes `@BuiltinFunction` annotation on the EnvFunction. This specific annotation on the class has been meaningless without corresponding `@AutoService(Function.class)`.