### PR TITLE
Fix explode/0 against Unicode surrogate code points

### DIFF
--- a/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/functions/ExplodeFunction.java
+++ b/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/functions/ExplodeFunction.java
@@ -25,8 +25,8 @@ public class ExplodeFunction implements Function {
 		Preconditions.checkInputType("explode", in, JsonNodeType.STRING);
 
 		final ArrayNode result = scope.getObjectMapper().createArrayNode();
-		for (final char ch : in.asText().toCharArray())
-			result.add((int) ch);
+		for (final int ch : in.asText().codePoints().toArray())
+			result.add(ch);
 		output.emit(result, null);
 	}
 }

--- a/jackson-jq/src/test/resources/tests/functions/explode.yaml
+++ b/jackson-jq/src/test/resources/tests/functions/explode.yaml
@@ -1,0 +1,4 @@
+- q: 'explode'
+  in: "\\ud83d\\ude04"
+  out:
+  - 128516


### PR DESCRIPTION
This PR fixes the `explode/0` filter on Unicode surrogate code points to be compatible against jq.
```sh
 $ jq explode <<< '"\ud83d\ude04"'
[
  128516
]

 $ jackson-jq explode <<< '"\ud83d\ude04"'
[ 55357, 56836 ]
```