### PR TITLE
Rename the long option for raw output strings

### DIFF
--- a/jackson-jq-cli/src/main/java/net/thisptr/jackson/jq/cli/Main.java
+++ b/jackson-jq-cli/src/main/java/net/thisptr/jackson/jq/cli/Main.java
@@ -42,8 +42,8 @@ public class Main {
 			.desc("compact instead of pretty-printed output")
 			.build();
 
-	private static final Option OPT_RAW = Option.builder("r")
-			.longOpt("raw")
+	private static final Option OPT_RAW_OUTPUT = Option.builder("r")
+			.longOpt("raw-output")
 			.desc("output raw strings, not JSON texts")
 			.build();
 
@@ -66,7 +66,7 @@ public class Main {
 	public static void main(String[] args) throws IOException, ParseException {
 		final Options options = new Options();
 		options.addOption(OPT_COMPACT);
-		options.addOption(OPT_RAW);
+		options.addOption(OPT_RAW_OUTPUT);
 		options.addOption(OPT_NULL_INPUT);
 		options.addOption(OPT_VERSION);
 		options.addOption(OPT_HELP);
@@ -126,7 +126,7 @@ public class Main {
 					continue;
 				try {
 					jq.apply(scope, tree, (out) -> {
-						if (out.isTextual() && command.hasOption(OPT_RAW.getOpt())) {
+						if (out.isTextual() && command.hasOption(OPT_RAW_OUTPUT.getOpt())) {
 							System.out.println(out.asText());
 						} else {
 							try {


### PR DESCRIPTION
This PR fixes the long option for raw output strings to be compatible with jq.