### PR TITLE
Implement error/0 and fix try catch against non-string errors

### DIFF
--- a/jackson-jq/src/main/java/net/thisptr/jackson/jq/exception/JsonQueryUserException.java
+++ b/jackson-jq/src/main/java/net/thisptr/jackson/jq/exception/JsonQueryUserException.java
@@ -2,10 +2,20 @@ package net.thisptr.jackson.jq.exception;
 
 import com.fasterxml.jackson.databind.JsonNode;
 
+import net.thisptr.jackson.jq.internal.misc.JsonNodeUtils;
+
 public class JsonQueryUserException extends JsonQueryException {
 	private static final long serialVersionUID = -2719442463094461632L;
 
-	public JsonQueryUserException(final JsonNode msg) {
-		super(msg.asText());
+	private JsonNode value;
+
+	public JsonQueryUserException(final JsonNode value) {
+		super(value.isTextual() ? value.asText() : JsonNodeUtils.toString(value));
+		this.value = value;
+	}
+
+	@Override
+	public JsonNode getMessageAsJsonNode() {
+		return value;
 	}
 }

--- a/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/functions/ErrorFunction.java
+++ b/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/functions/ErrorFunction.java
@@ -16,14 +16,20 @@ import net.thisptr.jackson.jq.exception.JsonQueryUserException;
 import net.thisptr.jackson.jq.path.Path;
 
 @AutoService(Function.class)
-@BuiltinFunction("error/1")
+@BuiltinFunction({ "error/0", "error/1" })
 public class ErrorFunction implements Function {
 	@Override
 	public void apply(final Scope scope, final List<Expression> args, final JsonNode in, final Path ipath, final PathOutput output, final Version version) throws JsonQueryException {
-		args.get(0).apply(scope, in, (out) -> {
-			if (out.isNull())
+		if (args.size() == 0) {
+			if (in.isNull())
 				return;
-			throw new JsonQueryUserException(out);
-		});
+			throw new JsonQueryUserException(in);
+		} else {
+			args.get(0).apply(scope, in, (out) -> {
+				if (out.isNull())
+					return;
+				throw new JsonQueryUserException(out);
+			});
+		}
 	}
 }

--- a/jackson-jq/src/test/resources/tests/functions/error.yaml
+++ b/jackson-jq/src/test/resources/tests/functions/error.yaml
@@ -1,9 +1,28 @@
-- {"v":"[1.5,1.5]","q":"error(empty)","in":null,"out":[]}
+- q: 'error'
+  in: null
+  out: []
+  v: "[1.5,1.5]"
+- q: 'try error catch .'
+  in: foo
+  out:
+  - foo
+- q: 'try error catch .'
+  in: 0
+  out:
+  - 0
+
+- q: 'error(empty)'
+  in: null
+  out: []
+  v: "[1.5,1.5]"
 - q: 'try error("a", error("foo")) catch .'
   out:
   - a
 - q: 'try error(error("foo")) catch .'
   out:
   - foo
+- q: 'try error({x:0}) catch .'
+  out:
+  - {"x":0}
 - q: 'error(null)'
   out: []


### PR DESCRIPTION
I implemented `error/0` function; `jq -n '"message" | error'`. I also fixed `JsonQueryUserException` so that `try error catch .` correctly works against non-strings; `jq -n '{x:0} | try error catch .'`.