### PR TITLE
Fix array indexing by empty array and refactor indices/1

### DIFF
--- a/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/functions/IndicesFunction.java
+++ b/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/functions/IndicesFunction.java
@@ -53,16 +53,11 @@ public class IndicesFunction implements Function {
 			}
 		} else if (needle.isArray() && haystack.isArray()) {
 			if (needle.size() != 0) {
-				for (int i = 0; i < haystack.size(); ++i) {
-					boolean match = true;
-					for (int j = 0; j < needle.size(); ++j) {
-						if (i + j >= haystack.size() || comparator.compare(haystack.get(i + j), needle.get(j)) != 0) {
-							match = false;
-							break;
-						}
-					}
-					if (match)
-						result.add(i);
+				shift: for (int i = 0; i < haystack.size() - needle.size() + 1; ++i) {
+					for (int j = 0; j < needle.size(); ++j)
+						if (comparator.compare(haystack.get(i + j), needle.get(j)) != 0)
+							continue shift;
+					result.add(i);
 				}
 			}
 		} else if (haystack.isArray()) {

--- a/jackson-jq/src/main/java/net/thisptr/jackson/jq/path/ArrayIndexOfPath.java
+++ b/jackson-jq/src/main/java/net/thisptr/jackson/jq/path/ArrayIndexOfPath.java
@@ -57,13 +57,13 @@ public class ArrayIndexOfPath implements Path {
 		final JsonNodeComparator comparator = JsonNodeComparator.getInstance();
 		final ArrayNode out = MAPPER.createArrayNode();
 
-		shift: for (int i = 0; i < seq.size() - subseq.size() + 1; ++i) {
-			for (int j = 0; j < subseq.size(); ++j) {
-				final int r = comparator.compare(seq.get(i + j), subseq.get(j));
-				if (r != 0)
-					continue shift;
+		if (subseq.size() != 0) {
+			shift: for (int i = 0; i < seq.size() - subseq.size() + 1; ++i) {
+				for (int j = 0; j < subseq.size(); ++j)
+					if (comparator.compare(seq.get(i + j), subseq.get(j)) != 0)
+						continue shift;
+				out.add(IntNode.valueOf(i));
 			}
-			out.add(IntNode.valueOf(i));
 		}
 
 		return out;

--- a/jackson-jq/src/test/resources/tests/constructs/array_index.yaml
+++ b/jackson-jq/src/test/resources/tests/constructs/array_index.yaml
@@ -64,6 +64,16 @@
   out:
   - "Cannot update field at array index of array"
 
+- q: '.[[]]'
+  in: ["a", "b", "a", "a", "b"]
+  out:
+  - []
+
+- q: 'path(.[[]])'
+  in: ["a", "b", "a", "a", "b"]
+  out:
+  - [[]]
+
 - q: '.[2:0] = [999]'
   in: [0, 1, 2, 3, 4]
   out:


### PR DESCRIPTION
This PR fixes array indexing by array (`[1,2,3,2,1] | .[[]]` should emit `[]`). This operation behaves the same as `indices/1` function. I looked into the function implementation and refactored a bit.
