### PR TITLE
Skip writing NaN on csv and tsv formats

### DIFF
--- a/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/filters/AbstractSvFilter.java
+++ b/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/filters/AbstractSvFilter.java
@@ -36,7 +36,7 @@ public abstract class AbstractSvFilter implements Function {
 
 			if (col.isTextual()) {
 				appendEscaped(row, col.asText());
-			} else if (col.isNull()) {
+			} else if (col.isNull() || col.isNumber() && Double.isNaN(col.asDouble())) {
 				// empty
 			} else if (col.isBoolean() || col.isNumber()) {
 				try {

--- a/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/functions/IsNanFunction.java
+++ b/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/functions/IsNanFunction.java
@@ -15,6 +15,6 @@ public class IsNanFunction extends JsonPredicateFunction {
 	}
 
 	private static boolean test(final JsonNode value) {
-		return (value.isDouble() || value.isFloat()) && Double.isNaN(value.asDouble());
+		return value.isNumber() && Double.isNaN(value.asDouble());
 	}
 }

--- a/jackson-jq/src/test/resources/tests/functions/@csv.yaml
+++ b/jackson-jq/src/test/resources/tests/functions/@csv.yaml
@@ -8,6 +8,10 @@
   out:
   - "0"
 
+- q: '[0,null,nan,infinite] | @csv'
+  out:
+  - "0,,,1.7976931348623157e+308"
+
 - q: '[[range(0; 128)] | implode] | @csv'
   out:
   - "\"\\0\u0001\u0002\u0003\u0004\u0005\u0006\u0007\b\t\n\u000b\f\r\u000e\u000f\u0010\u0011\u0012\u0013\u0014\u0015\u0016\u0017\u0018\u0019\u001a\u001b\u001c\u001d\u001e\u001f !\"\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~\u007f\""

--- a/jackson-jq/src/test/resources/tests/functions/@tsv.yaml
+++ b/jackson-jq/src/test/resources/tests/functions/@tsv.yaml
@@ -8,6 +8,10 @@
   out:
   - "0"
 
+- q: '[0,null,nan,infinite] | @tsv'
+  out:
+  - "0\t\t\t1.7976931348623157e+308"
+
 - q: '[[range(0; 128)] | implode] | @tsv'
   out:
   - "\\0\u0001\u0002\u0003\u0004\u0005\u0006\u0007\b\\t\\n\u000b\f\\r\u000e\u000f\u0010\u0011\u0012\u0013\u0014\u0015\u0016\u0017\u0018\u0019\u001a\u001b\u001c\u001d\u001e\u001f !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\\\]^_`abcdefghijklmnopqrstuvwxyz{|}~\u007f"


### PR DESCRIPTION
This PR improves jq compatibility of `@csv` and `@tsv` formats by skipping NaN.