### PR TITLE
Improve the jackson-jq bash script

### DIFF
--- a/bin/jackson-jq
+++ b/bin/jackson-jq
@@ -1,12 +1,13 @@
 #!/bin/bash
+set -euo pipefail
 
-scriptpath=`readlink -f $0`
-scriptdir=`dirname $scriptpath`
+scriptpath=$(readlink -f -- "${BASH_SOURCE[0]}")
+scriptdir=$(dirname -- "$scriptpath")
 
-jarpath=`find $scriptdir/../jackson-jq-cli -name "jackson-jq-cli-*.jar" | grep -v sources | grep -v javadoc`
-if [ -z $jarpath ]; then
-    echo "ERROR: jackson-jar-cli-\${version}.jar does not exist; please run 'mvn package' first." 1>&2
+jarpath=$(find "$scriptdir/../jackson-jq-cli" -name "jackson-jq-cli-*.jar" -not -name "*sources*" -not -name "*javadoc*")
+if [[ -z "$jarpath" ]]; then
+    echo "ERROR: jackson-jar-cli-\${version}.jar does not exist; please run 'mvn package' first." >&2
     exit 1
 fi
 
-java -jar $jarpath "$@"
+exec java -jar "$jarpath" "$@"


### PR DESCRIPTION
This PR proposes various improvements to the bash script `jackson-jq`. I propose to make the script passes `shellcheck`, and to use `exec` on executing the JAR file for better signal handling.