### PR TITLE
Upgrade to jackson 2.18.0

### DIFF
--- a/jackson-jq/pom.xml
+++ b/jackson-jq/pom.xml
@@ -13,6 +13,14 @@
 
 	<dependencies>
 		<dependency>
+			<groupId>com.fasterxml.jackson.core</groupId>
+			<artifactId>jackson-annotations</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>com.fasterxml.jackson.core</groupId>
+			<artifactId>jackson-databind</artifactId>
+		</dependency>
+		<dependency>
 			<groupId>org.jruby.joni</groupId>
 			<artifactId>joni</artifactId>
 			<version>2.2.1</version>
@@ -26,7 +34,6 @@
 		<dependency>
 			<groupId>com.fasterxml.jackson.dataformat</groupId>
 			<artifactId>jackson-dataformat-yaml</artifactId>
-			<version>${com.fasterxml.jackson-version}</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -44,19 +44,30 @@
 		</snapshotRepository>
 	</distributionManagement>
 
+
 	<properties>
 		<org.slf4j-version>1.7.36</org.slf4j-version>
-		<com.fasterxml.jackson-version>2.16.1</com.fasterxml.jackson-version>
-		<com.fasterxml.jackson.databind-version>2.16.1</com.fasterxml.jackson.databind-version>
+		<com.fasterxml.jackson-version>2.18.0</com.fasterxml.jackson-version>
 		<com.google.auto.service-version>1.1.1</com.google.auto.service-version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 	</properties>
+
+	<dependencyManagement>
+		<dependencies>
+			<dependency>
+				<groupId>com.fasterxml.jackson</groupId>
+				<artifactId>jackson-bom</artifactId>
+				<version>${com.fasterxml.jackson-version}</version>
+				<type>pom</type>
+				<scope>import</scope>
+			</dependency>
+		</dependencies>
+	</dependencyManagement>
 
 	<dependencies>
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-databind</artifactId>
-			<version>${com.fasterxml.jackson.databind-version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.junit.jupiter</groupId>


### PR DESCRIPTION
Jackson 2.18.x is the latest version 

https://github.com/FasterXML/jackson/wiki/Jackson-Release-2.18
