### PR TITLE
ci: install missing jq-1.7 that is required for testing

### DIFF
--- a/.github/workflows/deploy-snapshot.yaml
+++ b/.github/workflows/deploy-snapshot.yaml
@@ -20,7 +20,8 @@ jobs:
         mkdir -p $HOME/bin
         wget -O $HOME/bin/jq-1.5 https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64
         wget -O $HOME/bin/jq-1.6 https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64
-        chmod +x $HOME/bin/jq-1.5 $HOME/bin/jq-1.6
+        wget -O $HOME/bin/jq-1.7 https://github.com/jqlang/jq/releases/download/jq-1.7.1/jq-linux-amd64
+        chmod +x $HOME/bin/jq-1.5 $HOME/bin/jq-1.6 $HOME/bin/jq-1.7
 
     - name: Configure Maven
       env:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -28,7 +28,8 @@ jobs:
         mkdir -p $HOME/bin
         wget -O $HOME/bin/jq-1.5 https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64
         wget -O $HOME/bin/jq-1.6 https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64
-        chmod +x $HOME/bin/jq-1.5 $HOME/bin/jq-1.6
+        wget -O $HOME/bin/jq-1.7 https://github.com/jqlang/jq/releases/download/jq-1.7.1/jq-linux-amd64
+        chmod +x $HOME/bin/jq-1.5 $HOME/bin/jq-1.6 $HOME/bin/jq-1.7
 
     - name: Configure Maven
       env:

--- a/.github/workflows/test-pull-requests.yaml
+++ b/.github/workflows/test-pull-requests.yaml
@@ -19,7 +19,8 @@ jobs:
         mkdir -p $HOME/bin
         wget -O $HOME/bin/jq-1.5 https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64
         wget -O $HOME/bin/jq-1.6 https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64
-        chmod +x $HOME/bin/jq-1.5 $HOME/bin/jq-1.6
+        wget -O $HOME/bin/jq-1.7 https://github.com/jqlang/jq/releases/download/jq-1.7.1/jq-linux-amd64
+        chmod +x $HOME/bin/jq-1.5 $HOME/bin/jq-1.6 $HOME/bin/jq-1.7
 
     - name: Build & Deploy
       run: 'PATH="$HOME/bin:$PATH" mvn clean package'


### PR DESCRIPTION
#439 added tests that require jq-1.7 binary to be present.