### PR TITLE
Add Automatic-Module-Name to MANIFEST.MF

### DIFF
--- a/jackson-jq-extra/pom.xml
+++ b/jackson-jq-extra/pom.xml
@@ -30,7 +30,7 @@
 					</instructions>
 					<archive>
 						<manifestEntries>
-							<Automatic-Module-Name>jackson-jq-extra</Automatic-Module-Name>
+							<Automatic-Module-Name>net.thisptr.jackson.jq.extra</Automatic-Module-Name>
 						</manifestEntries>
 					</archive>
 				</configuration>

--- a/jackson-jq-extra/pom.xml
+++ b/jackson-jq-extra/pom.xml
@@ -28,6 +28,11 @@
 					<instructions>
 						<Include-Resource>META-INF/services/net.thisptr.jackson.jq.Function=${project.build.outputDirectory}/META-INF/services/net.thisptr.jackson.jq.Function,META-INF/services/net.thisptr.jackson.jq.module.Module=${project.build.outputDirectory}/META-INF/services/net.thisptr.jackson.jq.module.Module,META-INF/jandex.idx=${project.build.outputDirectory}/META-INF/jandex.idx</Include-Resource>
 					</instructions>
+					<archive>
+						<manifestEntries>
+							<Automatic-Module-Name>jackson-jq-extra</Automatic-Module-Name>
+						</manifestEntries>
+					</archive>
 				</configuration>
 			</plugin>
 			<plugin>

--- a/jackson-jq/pom.xml
+++ b/jackson-jq/pom.xml
@@ -72,6 +72,11 @@
 					<instructions>
 						<Include-Resource>META-INF/services/net.thisptr.jackson.jq.Function=${project.build.outputDirectory}/META-INF/services/net.thisptr.jackson.jq.Function,META-INF/jandex.idx=${project.build.outputDirectory}/META-INF/jandex.idx</Include-Resource>
 					</instructions>
+					<archive>
+						<manifestEntries>
+							<Automatic-Module-Name>jackson-jq</Automatic-Module-Name>
+						</manifestEntries>
+					</archive>
 				</configuration>
 			</plugin>
 			<plugin>

--- a/jackson-jq/pom.xml
+++ b/jackson-jq/pom.xml
@@ -74,7 +74,7 @@
 					</instructions>
 					<archive>
 						<manifestEntries>
-							<Automatic-Module-Name>jackson-jq</Automatic-Module-Name>
+							<Automatic-Module-Name>net.thisptr.jackson.jq</Automatic-Module-Name>
 						</manifestEntries>
 					</archive>
 				</configuration>


### PR DESCRIPTION
This gives both `jackson-jq` and `jackson-jq-extra` a Java 9 module name without having to upgrade to Java 9. This makes it possible for other libraries that are Java 9 modules to be published in public repositories. See also issue #471.