### PR TITLE
Adds support for native-image

### DIFF
--- a/.github/workflows/test-pull-requests.yaml
+++ b/.github/workflows/test-pull-requests.yaml
@@ -6,13 +6,34 @@ on:
 jobs:
   build:
     runs-on: ubuntu-22.04
+    strategy:
+      matrix:
+        java-env:
+          - name: "JDK 1.8"
+            java-version: "8"
+            distribution: "temurin"
+            maven-command: "mvn clean package"
+          - name: "GraalVM 21"
+            java-version: "21"
+            distribution: "graalvm-community"
+            maven-command: "mvn clean package -Pnative"
+    name: "Build with ${{ matrix.java-env.name }}"
     steps:
     - uses: actions/checkout@v4.2.2
+    
     - name: Set up JDK 1.8
+      if: matrix.java-env.name == 'JDK 1.8'
       uses: actions/setup-java@v4.7.1
       with:
-        java-version: '8'
-        distribution: 'temurin'
+        java-version: ${{ matrix.java-env.java-version }}
+        distribution: ${{ matrix.java-env.distribution }}
+
+    - name: Set up GraalVM 21
+      if: matrix.java-env.name == 'GraalVM 21'
+      uses: graalvm/setup-graalvm@v1
+      with:
+        java-version: ${{ matrix.java-env.java-version }}
+        distribution: ${{ matrix.java-env.distribution }}
 
     - name: Download jq-1.5 and jq-1.6
       run: |
@@ -23,4 +44,4 @@ jobs:
         chmod +x $HOME/bin/jq-1.5 $HOME/bin/jq-1.6 $HOME/bin/jq-1.7
 
     - name: Build & Deploy
-      run: 'PATH="$HOME/bin:$PATH" mvn clean package'
+      run: 'PATH="$HOME/bin:$PATH" ${{ matrix.java-env.maven-command }}'

--- a/jackson-jq/pom.xml
+++ b/jackson-jq/pom.xml
@@ -70,7 +70,12 @@
 				<artifactId>maven-bundle-plugin</artifactId>
 				<configuration>
 					<instructions>
-						<Include-Resource>META-INF/services/net.thisptr.jackson.jq.Function=${project.build.outputDirectory}/META-INF/services/net.thisptr.jackson.jq.Function,META-INF/jandex.idx=${project.build.outputDirectory}/META-INF/jandex.idx</Include-Resource>
+						<Include-Resource>
+							META-INF/services/net.thisptr.jackson.jq.Function=${project.build.outputDirectory}/META-INF/services/net.thisptr.jackson.jq.Function,
+							META-INF/jandex.idx=${project.build.outputDirectory}/META-INF/jandex.idx,
+							META-INF/native-image/resource-config.json=${project.build.outputDirectory}/META-INF/native-image/resource-config.json,
+							META-INF/native-image/reflect-config.json=${project.build.outputDirectory}/META-INF/native-image/reflect-config.json
+						</Include-Resource>
 					</instructions>
 					<archive>
 						<manifestEntries>

--- a/jackson-jq/pom.xml
+++ b/jackson-jq/pom.xml
@@ -44,6 +44,44 @@
 		</dependency>
 	</dependencies>
 
+	<profiles>
+		<profile>
+			<id>native</id>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.graalvm.buildtools</groupId>
+						<artifactId>native-maven-plugin</artifactId>
+						<version>0.11.0</version>
+						<extensions>true</extensions>
+						<executions>
+							<execution>
+								<id>test-native</id>
+								<goals>
+									<goal>generateTestResourceConfig</goal>
+									<goal>test</goal>
+								</goals>
+								<phase>test</phase>
+								<configuration>
+									<resourceIncludedPatterns>
+										<pattern>classpath_modules(/.*\.(jq|json))?</pattern>
+										<pattern>tests(/.*\.ya?ml)?</pattern>
+										<pattern>failing_tests(/.*\.ya?ml)?</pattern>
+										<pattern>jq-test-extra-ok.json</pattern>
+										<pattern>librocksdbjni-.*.(so|jnilib|dll)</pattern>
+									</resourceIncludedPatterns>
+								</configuration>
+							</execution>
+						</executions>
+						<configuration>
+							<fallback>false</fallback>
+						</configuration>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+	</profiles>
+
 	<build>
 		<plugins>
 			<plugin>
@@ -75,7 +113,7 @@
 							META-INF/jandex.idx=${project.build.outputDirectory}/META-INF/jandex.idx,
 							META-INF/native-image/resource-config.json=${project.build.outputDirectory}/META-INF/native-image/resource-config.json,
 							META-INF/native-image/reflect-config.json=${project.build.outputDirectory}/META-INF/native-image/reflect-config.json,
-                            META-INF/native-image/native-image.properties=${project.build.outputDirectory}/META-INF/native-image/native-image.properties
+							META-INF/native-image/native-image.properties=${project.build.outputDirectory}/META-INF/native-image/native-image.properties
 						</Include-Resource>
 					</instructions>
 					<archive>

--- a/jackson-jq/pom.xml
+++ b/jackson-jq/pom.xml
@@ -74,7 +74,8 @@
 							META-INF/services/net.thisptr.jackson.jq.Function=${project.build.outputDirectory}/META-INF/services/net.thisptr.jackson.jq.Function,
 							META-INF/jandex.idx=${project.build.outputDirectory}/META-INF/jandex.idx,
 							META-INF/native-image/resource-config.json=${project.build.outputDirectory}/META-INF/native-image/resource-config.json,
-							META-INF/native-image/reflect-config.json=${project.build.outputDirectory}/META-INF/native-image/reflect-config.json
+							META-INF/native-image/reflect-config.json=${project.build.outputDirectory}/META-INF/native-image/reflect-config.json,
+                            META-INF/native-image/native-image.properties=${project.build.outputDirectory}/META-INF/native-image/native-image.properties
 						</Include-Resource>
 					</instructions>
 					<archive>

--- a/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/tree/binaryop/BinaryOperatorExpression.java
+++ b/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/tree/binaryop/BinaryOperatorExpression.java
@@ -40,32 +40,144 @@ public abstract class BinaryOperatorExpression implements Expression {
 	}
 
 	public enum Operator {
-		ASSIGN("=", 6, Associativity.RIGHT),
-		UDPATE("|=", 6, Associativity.RIGHT),
-		DEFAULT_EQUAL("//=", 6, Associativity.RIGHT),
-		PLUS_EQUAL("+=", 6, Associativity.RIGHT),
-		MINUS_EQUAL("-=", 6, Associativity.RIGHT),
-		TIMES_EQUAL("*=", 6, Associativity.RIGHT),
-		DIVIDE_EQUAL("/=", 6, Associativity.RIGHT),
-		MODULO_EQUAL("%=", 6, Associativity.RIGHT),
-		DEFAULT("//", 5, Associativity.LEFT),
-		OR("or", 4, Associativity.LEFT),
-		AND("and", 4, Associativity.LEFT),
-		LESS_EQUAL("<=", 3, Associativity.LEFT),
-		LESS("<", 3, Associativity.LEFT),
-		GREATER_EQUAL(">=", 3, Associativity.LEFT),
-		GREATER(">", 3, Associativity.LEFT),
-		EQUAL("==", 3, Associativity.LEFT),
-		NOT_EQUAL("!=", 3, Associativity.LEFT),
-		PLUS("+", 2, Associativity.LEFT),
-		MINUS("-", 2, Associativity.LEFT),
-		MODULO("%", 1, Associativity.LEFT),
-		DIVIDE("/", 1, Associativity.LEFT),
-		TIMES("*", 1, Associativity.LEFT);
+        ASSIGN("=", 6, Associativity.RIGHT) {
+            @Override
+            protected Expression create(Expression lhs, Expression rhs, Version version) {
+                return new Assignment(lhs, rhs);
+            }
+        },
+        UDPATE("|=", 6, Associativity.RIGHT) {
+            @Override
+            protected Expression create(Expression lhs, Expression rhs, Version version) {
+                return new UpdateAssignment(lhs, rhs, version);
+            }
+        },
+        DEFAULT_EQUAL("//=", 6, Associativity.RIGHT) {
+            @Override
+            protected Expression create(Expression lhs, Expression rhs, Version version) {
+                return new ComplexAlternativeAssignment(lhs, rhs);
+            }
+        },
+        PLUS_EQUAL("+=", 6, Associativity.RIGHT) {
+            @Override
+            protected Expression create(Expression lhs, Expression rhs, Version version) {
+                return new ComplexPlusAssignment(lhs, rhs);
+            }
+        },
+        MINUS_EQUAL("-=", 6, Associativity.RIGHT) {
+            @Override
+            protected Expression create(Expression lhs, Expression rhs, Version version) {
+                return new ComplexMinusAssignment(lhs, rhs);
+            }
+        },
+        TIMES_EQUAL("*=", 6, Associativity.RIGHT) {
+            @Override
+            protected Expression create(Expression lhs, Expression rhs, Version version) {
+                return new ComplexMultiplyAssignment(lhs, rhs);
+            }
+        },
+        DIVIDE_EQUAL("/=", 6, Associativity.RIGHT) {
+            @Override
+            protected Expression create(Expression lhs, Expression rhs, Version version) {
+                return new ComplexDivideAssignment(lhs, rhs);
+            }
+        },
+        MODULO_EQUAL("%=", 6, Associativity.RIGHT) {
+            @Override
+            protected Expression create(Expression lhs, Expression rhs, Version version) {
+                return new ComplexModuloAssignment(lhs, rhs);
+            }
+        },
+        DEFAULT("//", 5, Associativity.LEFT) {
+            @Override
+            protected Expression create(Expression lhs, Expression rhs, Version version) {
+                return new AlternativeOperatorExpression(lhs, rhs);
+            }
+        },
+        OR("or", 4, Associativity.LEFT) {
+            @Override
+            protected Expression create(Expression lhs, Expression rhs, Version version) {
+                return new BooleanOrExpression(lhs, rhs);
+            }
+        },
+        AND("and", 4, Associativity.LEFT) {
+            @Override
+            protected Expression create(Expression lhs, Expression rhs, Version version) {
+                return new BooleanAndExpression(lhs, rhs);
+            }
+        },
+        LESS_EQUAL("<=", 3, Associativity.LEFT) {
+            @Override
+            protected Expression create(Expression lhs, Expression rhs, Version version) {
+                return new CompareLessEqualTest(lhs, rhs);
+            }
+        },
+        LESS("<", 3, Associativity.LEFT) {
+            @Override
+            protected Expression create(Expression lhs, Expression rhs, Version version) {
+                return new CompareLessTest(lhs, rhs);
+            }
+        },
+        GREATER_EQUAL(">=", 3, Associativity.LEFT) {
+            @Override
+            protected Expression create(Expression lhs, Expression rhs, Version version) {
+                return new CompareGreaterEqualTest(lhs, rhs);
+            }
+        },
+        GREATER(">", 3, Associativity.LEFT) {
+            @Override
+            protected Expression create(Expression lhs, Expression rhs, Version version) {
+                return new CompareGreaterTest(lhs, rhs);
+            }
+        },
+        EQUAL("==", 3, Associativity.LEFT) {
+            @Override
+            protected Expression create(Expression lhs, Expression rhs, Version version) {
+                return new CompareEqualTest(lhs, rhs);
+            }
+        },
+        NOT_EQUAL("!=", 3, Associativity.LEFT) {
+            @Override
+            protected Expression create(Expression lhs, Expression rhs, Version version) {
+                return new CompareNotEqualTest(lhs, rhs);
+            }
+        },
+        PLUS("+", 2, Associativity.LEFT) {
+            @Override
+            protected Expression create(Expression lhs, Expression rhs, Version version) {
+                return new PlusExpression(lhs, rhs);
+            }
+        },
+        MINUS("-", 2, Associativity.LEFT) {
+            @Override
+            protected Expression create(Expression lhs, Expression rhs, Version version) {
+                return new MinusExpression(lhs, rhs);
+            }
+        },
+        MODULO("%", 1, Associativity.LEFT) {
+            @Override
+            protected Expression create(Expression lhs, Expression rhs, Version version) {
+                return new ModuloExpression(lhs, rhs);
+            }
+        },
+        DIVIDE("/", 1, Associativity.LEFT) {
+            @Override
+            protected Expression create(Expression lhs, Expression rhs, Version version) {
+                return new DivideExpression(lhs, rhs);
+            }
+        },
+        TIMES("*", 1, Associativity.LEFT) {
+            @Override
+            protected Expression create(Expression lhs, Expression rhs, Version version) {
+                return new MultiplyExpression(lhs, rhs);
+            }
+        };
 
 		public final String image;
 		public final int precedence;
 		public final Associativity associativity;
+
+        protected abstract Expression create(Expression lhs, Expression rhs,  Version version);
 
 		public enum Associativity {
 			LEFT, RIGHT
@@ -92,54 +204,7 @@ public abstract class BinaryOperatorExpression implements Expression {
 
 		public Expression buildTree(final Expression lhs, final Expression rhs, final Version version) {
 			try {
-                switch (this) {
-                    case ASSIGN:
-                        return new Assignment(lhs, rhs);
-                    case UDPATE:
-                        return new UpdateAssignment(lhs, rhs, version);
-                    case DEFAULT_EQUAL:
-                        return new ComplexAlternativeAssignment(lhs, rhs);
-                    case PLUS_EQUAL:
-                        return new ComplexPlusAssignment(lhs, rhs);
-                    case MINUS_EQUAL:
-                        return new ComplexMinusAssignment(lhs, rhs);
-                    case TIMES_EQUAL:
-                        return new ComplexMultiplyAssignment(lhs, rhs);
-                    case DIVIDE_EQUAL:
-                        return new ComplexDivideAssignment(lhs, rhs);
-                    case MODULO_EQUAL:
-                        return new ComplexModuloAssignment(lhs, rhs);
-                    case DEFAULT:
-                        return new AlternativeOperatorExpression(lhs, rhs);
-                    case OR:
-                        return new BooleanOrExpression(lhs, rhs);
-                    case AND:
-                        return new BooleanAndExpression(lhs, rhs);
-                    case LESS_EQUAL:
-                        return new CompareLessEqualTest(lhs, rhs);
-                    case LESS:
-                        return new CompareLessTest(lhs, rhs);
-                    case GREATER_EQUAL:
-                        return new CompareGreaterEqualTest(lhs, rhs);
-                    case GREATER:
-                        return new CompareGreaterTest(lhs, rhs);
-                    case EQUAL:
-                        return new CompareEqualTest(lhs, rhs);
-                    case NOT_EQUAL:
-                        return new CompareNotEqualTest(lhs, rhs);
-                    case PLUS:
-                        return new PlusExpression(lhs, rhs);
-                    case MINUS:
-                        return new MinusExpression(lhs, rhs);
-                    case MODULO:
-                        return new ModuloExpression(lhs, rhs);
-                    case DIVIDE:
-                        return new DivideExpression(lhs, rhs);
-                    case TIMES:
-                        return new MultiplyExpression(lhs, rhs);
-                    default:
-                        throw new IllegalStateException("Unknown operator: " + this);
-                }
+                return create(lhs, rhs, version);
 			} catch (Exception e) {
 				throw new RuntimeException(e);
 			}

--- a/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/tree/binaryop/BinaryOperatorExpression.java
+++ b/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/tree/binaryop/BinaryOperatorExpression.java
@@ -40,144 +40,153 @@ public abstract class BinaryOperatorExpression implements Expression {
 	}
 
 	public enum Operator {
-        ASSIGN("=", 6, Associativity.RIGHT) {
-            @Override
-            protected Expression create(Expression lhs, Expression rhs, Version version) {
-                return new Assignment(lhs, rhs);
-            }
-        },
-        UDPATE("|=", 6, Associativity.RIGHT) {
-            @Override
-            protected Expression create(Expression lhs, Expression rhs, Version version) {
-                return new UpdateAssignment(lhs, rhs, version);
-            }
-        },
-        DEFAULT_EQUAL("//=", 6, Associativity.RIGHT) {
-            @Override
-            protected Expression create(Expression lhs, Expression rhs, Version version) {
-                return new ComplexAlternativeAssignment(lhs, rhs);
-            }
-        },
-        PLUS_EQUAL("+=", 6, Associativity.RIGHT) {
-            @Override
-            protected Expression create(Expression lhs, Expression rhs, Version version) {
-                return new ComplexPlusAssignment(lhs, rhs);
-            }
-        },
-        MINUS_EQUAL("-=", 6, Associativity.RIGHT) {
-            @Override
-            protected Expression create(Expression lhs, Expression rhs, Version version) {
-                return new ComplexMinusAssignment(lhs, rhs);
-            }
-        },
-        TIMES_EQUAL("*=", 6, Associativity.RIGHT) {
-            @Override
-            protected Expression create(Expression lhs, Expression rhs, Version version) {
-                return new ComplexMultiplyAssignment(lhs, rhs);
-            }
-        },
-        DIVIDE_EQUAL("/=", 6, Associativity.RIGHT) {
-            @Override
-            protected Expression create(Expression lhs, Expression rhs, Version version) {
-                return new ComplexDivideAssignment(lhs, rhs);
-            }
-        },
-        MODULO_EQUAL("%=", 6, Associativity.RIGHT) {
-            @Override
-            protected Expression create(Expression lhs, Expression rhs, Version version) {
-                return new ComplexModuloAssignment(lhs, rhs);
-            }
-        },
-        DEFAULT("//", 5, Associativity.LEFT) {
-            @Override
-            protected Expression create(Expression lhs, Expression rhs, Version version) {
-                return new AlternativeOperatorExpression(lhs, rhs);
-            }
-        },
-        OR("or", 4, Associativity.LEFT) {
-            @Override
-            protected Expression create(Expression lhs, Expression rhs, Version version) {
-                return new BooleanOrExpression(lhs, rhs);
-            }
-        },
-        AND("and", 4, Associativity.LEFT) {
-            @Override
-            protected Expression create(Expression lhs, Expression rhs, Version version) {
-                return new BooleanAndExpression(lhs, rhs);
-            }
-        },
-        LESS_EQUAL("<=", 3, Associativity.LEFT) {
-            @Override
-            protected Expression create(Expression lhs, Expression rhs, Version version) {
-                return new CompareLessEqualTest(lhs, rhs);
-            }
-        },
-        LESS("<", 3, Associativity.LEFT) {
-            @Override
-            protected Expression create(Expression lhs, Expression rhs, Version version) {
-                return new CompareLessTest(lhs, rhs);
-            }
-        },
-        GREATER_EQUAL(">=", 3, Associativity.LEFT) {
-            @Override
-            protected Expression create(Expression lhs, Expression rhs, Version version) {
-                return new CompareGreaterEqualTest(lhs, rhs);
-            }
-        },
-        GREATER(">", 3, Associativity.LEFT) {
-            @Override
-            protected Expression create(Expression lhs, Expression rhs, Version version) {
-                return new CompareGreaterTest(lhs, rhs);
-            }
-        },
-        EQUAL("==", 3, Associativity.LEFT) {
-            @Override
-            protected Expression create(Expression lhs, Expression rhs, Version version) {
-                return new CompareEqualTest(lhs, rhs);
-            }
-        },
-        NOT_EQUAL("!=", 3, Associativity.LEFT) {
-            @Override
-            protected Expression create(Expression lhs, Expression rhs, Version version) {
-                return new CompareNotEqualTest(lhs, rhs);
-            }
-        },
-        PLUS("+", 2, Associativity.LEFT) {
-            @Override
-            protected Expression create(Expression lhs, Expression rhs, Version version) {
-                return new PlusExpression(lhs, rhs);
-            }
-        },
-        MINUS("-", 2, Associativity.LEFT) {
-            @Override
-            protected Expression create(Expression lhs, Expression rhs, Version version) {
-                return new MinusExpression(lhs, rhs);
-            }
-        },
-        MODULO("%", 1, Associativity.LEFT) {
-            @Override
-            protected Expression create(Expression lhs, Expression rhs, Version version) {
-                return new ModuloExpression(lhs, rhs);
-            }
-        },
-        DIVIDE("/", 1, Associativity.LEFT) {
-            @Override
-            protected Expression create(Expression lhs, Expression rhs, Version version) {
-                return new DivideExpression(lhs, rhs);
-            }
-        },
-        TIMES("*", 1, Associativity.LEFT) {
-            @Override
-            protected Expression create(Expression lhs, Expression rhs, Version version) {
-                return new MultiplyExpression(lhs, rhs);
-            }
-        };
+		ASSIGN("=", 6, Associativity.RIGHT) {
+			@Override
+			protected Expression create(Expression lhs, Expression rhs, Version version) {
+				return new Assignment(lhs, rhs);
+			}
+		},
+		UDPATE("|=", 6, Associativity.RIGHT) {
+			@Override
+			protected Expression create(Expression lhs, Expression rhs, Version version) {
+				return new UpdateAssignment(lhs, rhs, version);
+			}
+		},
+		DEFAULT_EQUAL("//=", 6, Associativity.RIGHT) {
+			@Override
+			protected Expression create(Expression lhs, Expression rhs, Version version) {
+				return new ComplexAlternativeAssignment(lhs, rhs);
+			}
+		},
+		PLUS_EQUAL("+=", 6, Associativity.RIGHT) {
+			@Override
+			protected Expression create(Expression lhs, Expression rhs, Version version) {
+				return new ComplexPlusAssignment(lhs, rhs);
+			}
+		},
+		MINUS_EQUAL("-=", 6, Associativity.RIGHT) {
+			@Override
+			protected Expression create(Expression lhs, Expression rhs, Version version) {
+				return new ComplexMinusAssignment(lhs, rhs);
+			}
+		},
+		TIMES_EQUAL("*=", 6, Associativity.RIGHT) {
+			@Override
+			protected Expression create(Expression lhs, Expression rhs, Version version) {
+				return new ComplexMultiplyAssignment(lhs, rhs);
+			}
+		},
+		DIVIDE_EQUAL("/=", 6, Associativity.RIGHT) {
+			@Override
+			protected Expression create(Expression lhs, Expression rhs, Version version) {
+				return new ComplexDivideAssignment(lhs, rhs);
+			}
+		},
+		MODULO_EQUAL("%=", 6, Associativity.RIGHT) {
+			@Override
+			protected Expression create(Expression lhs, Expression rhs, Version version) {
+				return new ComplexModuloAssignment(lhs, rhs);
+			}
+		},
+		DEFAULT("//", 5, Associativity.LEFT) {
+			@Override
+			protected Expression create(Expression lhs, Expression rhs, Version version) {
+				return new AlternativeOperatorExpression(lhs, rhs);
+			}
+		},
+		OR("or", 4, Associativity.LEFT) {
+			@Override
+			protected Expression create(Expression lhs, Expression rhs, Version version) {
+				return new BooleanOrExpression(lhs, rhs);
+			}
+		},
+		AND("and", 4, Associativity.LEFT) {
+			@Override
+			protected Expression create(Expression lhs, Expression rhs, Version version) {
+				return new BooleanAndExpression(lhs, rhs);
+			}
+		},
+		LESS_EQUAL("<=", 3, Associativity.LEFT) {
+			@Override
+			protected Expression create(Expression lhs, Expression rhs, Version version) {
+				return new CompareLessEqualTest(lhs, rhs);
+			}
+		},
+		LESS("<", 3, Associativity.LEFT) {
+			@Override
+			protected Expression create(Expression lhs, Expression rhs, Version version) {
+				return new CompareLessTest(lhs, rhs);
+			}
+		},
+		GREATER_EQUAL(">=", 3, Associativity.LEFT) {
+			@Override
+			protected Expression create(Expression lhs, Expression rhs, Version version) {
+				return new CompareGreaterEqualTest(lhs, rhs);
+			}
+		},
+		GREATER(">", 3, Associativity.LEFT) {
+			@Override
+			protected Expression create(Expression lhs, Expression rhs, Version version) {
+				return new CompareGreaterTest(lhs, rhs);
+			}
+		},
+		EQUAL("==", 3, Associativity.LEFT) {
+			@Override
+			protected Expression create(Expression lhs, Expression rhs, Version version) {
+				return new CompareEqualTest(lhs, rhs);
+			}
+		},
+		NOT_EQUAL("!=", 3, Associativity.LEFT) {
+			@Override
+			protected Expression create(Expression lhs, Expression rhs, Version version) {
+				return new CompareNotEqualTest(lhs, rhs);
+			}
+		},
+		PLUS("+", 2, Associativity.LEFT) {
+			@Override
+			protected Expression create(Expression lhs, Expression rhs, Version version) {
+				return new PlusExpression(lhs, rhs);
+			}
+		},
+		MINUS("-", 2, Associativity.LEFT) {
+			@Override
+			protected Expression create(Expression lhs, Expression rhs, Version version) {
+				return new MinusExpression(lhs, rhs);
+			}
+		},
+		MODULO("%", 1, Associativity.LEFT) {
+			@Override
+			protected Expression create(Expression lhs, Expression rhs, Version version) {
+				return new ModuloExpression(lhs, rhs);
+			}
+		},
+		DIVIDE("/", 1, Associativity.LEFT) {
+			@Override
+			protected Expression create(Expression lhs, Expression rhs, Version version) {
+				return new DivideExpression(lhs, rhs);
+			}
+		},
+		TIMES("*", 1, Associativity.LEFT) {
+			@Override
+			protected Expression create(Expression lhs, Expression rhs, Version version) {
+				return new MultiplyExpression(lhs, rhs);
+			}
+		};
 
 		public final String image;
 		public final int precedence;
 		public final Associativity associativity;
 
-        protected abstract Expression create(Expression lhs, Expression rhs,  Version version);
+		/**
+		 * Creates a new {@link Expression} instance based on the provided left-hand side (lhs) expression,
+		 * right-hand side (rhs) expression, and the specified version.
+		 *
+		 * @param lhs the left-hand side expression
+		 * @param rhs the right-hand side expression
+		 * @param version the version providing contextual information for the expression creation
+		 * @return a new instance of {@link Expression} that represents the operation between the lhs and rhs expressions
+		 */
+		protected abstract Expression create(Expression lhs, Expression rhs, Version version);
 
 		public enum Associativity {
 			LEFT, RIGHT
@@ -204,7 +213,7 @@ public abstract class BinaryOperatorExpression implements Expression {
 
 		public Expression buildTree(final Expression lhs, final Expression rhs, final Version version) {
 			try {
-                return create(lhs, rhs, version);
+				return create(lhs, rhs, version);
 			} catch (Exception e) {
 				throw new RuntimeException(e);
 			}

--- a/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/tree/binaryop/BinaryOperatorExpression.java
+++ b/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/tree/binaryop/BinaryOperatorExpression.java
@@ -1,12 +1,10 @@
 package net.thisptr.jackson.jq.internal.tree.binaryop;
 
-import java.lang.reflect.Constructor;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Stack;
-
 import net.thisptr.jackson.jq.Expression;
 import net.thisptr.jackson.jq.Version;
 import net.thisptr.jackson.jq.internal.tree.binaryop.BinaryOperatorExpression.Operator.Associativity;
@@ -42,62 +40,41 @@ public abstract class BinaryOperatorExpression implements Expression {
 	}
 
 	public enum Operator {
-		ASSIGN("=", 6, Associativity.RIGHT, Assignment.class),
-		UDPATE("|=", 6, Associativity.RIGHT, UpdateAssignment.class),
-		DEFAULT_EQUAL("//=", 6, Associativity.RIGHT, ComplexAlternativeAssignment.class),
-		PLUS_EQUAL("+=", 6, Associativity.RIGHT, ComplexPlusAssignment.class),
-		MINUS_EQUAL("-=", 6, Associativity.RIGHT, ComplexMinusAssignment.class),
-		TIMES_EQUAL("*=", 6, Associativity.RIGHT, ComplexMultiplyAssignment.class),
-		DIVIDE_EQUAL("/=", 6, Associativity.RIGHT, ComplexDivideAssignment.class),
-		MODULO_EQUAL("%=", 6, Associativity.RIGHT, ComplexModuloAssignment.class),
-		DEFAULT("//", 5, Associativity.LEFT, AlternativeOperatorExpression.class),
-		OR("or", 4, Associativity.LEFT, BooleanOrExpression.class),
-		AND("and", 4, Associativity.LEFT, BooleanAndExpression.class),
-		LESS_EQUAL("<=", 3, Associativity.LEFT, CompareLessEqualTest.class),
-		LESS("<", 3, Associativity.LEFT, CompareLessTest.class),
-		GREATER_EQUAL(">=", 3, Associativity.LEFT, CompareGreaterEqualTest.class),
-		GREATER(">", 3, Associativity.LEFT, CompareGreaterTest.class),
-		EQUAL("==", 3, Associativity.LEFT, CompareEqualTest.class),
-		NOT_EQUAL("!=", 3, Associativity.LEFT, CompareNotEqualTest.class),
-		PLUS("+", 2, Associativity.LEFT, PlusExpression.class),
-		MINUS("-", 2, Associativity.LEFT, MinusExpression.class),
-		MODULO("%", 1, Associativity.LEFT, ModuloExpression.class),
-		DIVIDE("/", 1, Associativity.LEFT, DivideExpression.class),
-		TIMES("*", 1, Associativity.LEFT, MultiplyExpression.class);
+		ASSIGN("=", 6, Associativity.RIGHT),
+		UDPATE("|=", 6, Associativity.RIGHT),
+		DEFAULT_EQUAL("//=", 6, Associativity.RIGHT),
+		PLUS_EQUAL("+=", 6, Associativity.RIGHT),
+		MINUS_EQUAL("-=", 6, Associativity.RIGHT),
+		TIMES_EQUAL("*=", 6, Associativity.RIGHT),
+		DIVIDE_EQUAL("/=", 6, Associativity.RIGHT),
+		MODULO_EQUAL("%=", 6, Associativity.RIGHT),
+		DEFAULT("//", 5, Associativity.LEFT),
+		OR("or", 4, Associativity.LEFT),
+		AND("and", 4, Associativity.LEFT),
+		LESS_EQUAL("<=", 3, Associativity.LEFT),
+		LESS("<", 3, Associativity.LEFT),
+		GREATER_EQUAL(">=", 3, Associativity.LEFT),
+		GREATER(">", 3, Associativity.LEFT),
+		EQUAL("==", 3, Associativity.LEFT),
+		NOT_EQUAL("!=", 3, Associativity.LEFT),
+		PLUS("+", 2, Associativity.LEFT),
+		MINUS("-", 2, Associativity.LEFT),
+		MODULO("%", 1, Associativity.LEFT),
+		DIVIDE("/", 1, Associativity.LEFT),
+		TIMES("*", 1, Associativity.LEFT);
 
 		public final String image;
 		public final int precedence;
 		public final Associativity associativity;
-		public final Class<? extends BinaryOperatorExpression> clazz;
-		public final Constructor<? extends BinaryOperatorExpression> constructor;
-		public final boolean versionAware;
 
 		public enum Associativity {
 			LEFT, RIGHT
 		}
 
-		private Operator(final String image, final int precedence, final Associativity associativity, final Class<? extends BinaryOperatorExpression> clazz) {
+		private Operator(final String image, final int precedence, final Associativity associativity) {
 			this.image = image;
 			this.precedence = precedence;
 			this.associativity = associativity;
-			this.clazz = clazz;
-
-			Constructor<? extends BinaryOperatorExpression> ctor;
-			boolean versionAware;
-			try {
-				try {
-					ctor = clazz.getConstructor(Expression.class, Expression.class, Version.class);
-					versionAware = true;
-				} catch (NoSuchMethodException e) {
-					ctor = clazz.getConstructor(Expression.class, Expression.class);
-					versionAware = false;
-				}
-			} catch (Exception e) {
-				throw new RuntimeException(e);
-			}
-
-			this.constructor = ctor;
-			this.versionAware = versionAware;
 		}
 
 		public static Operator fromImage(final String image) {
@@ -107,7 +84,7 @@ public abstract class BinaryOperatorExpression implements Expression {
 			return op;
 		}
 
-		private static Map<String, Operator> lookup = new HashMap<>();
+		private static final Map<String, Operator> lookup = new HashMap<>();
 		static {
 			for (final Operator op : Operator.values())
 				lookup.put(op.image, op);
@@ -115,9 +92,54 @@ public abstract class BinaryOperatorExpression implements Expression {
 
 		public Expression buildTree(final Expression lhs, final Expression rhs, final Version version) {
 			try {
-				if (versionAware)
-					return constructor.newInstance(lhs, rhs, version);
-				return constructor.newInstance(lhs, rhs);
+                switch (this) {
+                    case ASSIGN:
+                        return new Assignment(lhs, rhs);
+                    case UDPATE:
+                        return new UpdateAssignment(lhs, rhs, version);
+                    case DEFAULT_EQUAL:
+                        return new ComplexAlternativeAssignment(lhs, rhs);
+                    case PLUS_EQUAL:
+                        return new ComplexPlusAssignment(lhs, rhs);
+                    case MINUS_EQUAL:
+                        return new ComplexMinusAssignment(lhs, rhs);
+                    case TIMES_EQUAL:
+                        return new ComplexMultiplyAssignment(lhs, rhs);
+                    case DIVIDE_EQUAL:
+                        return new ComplexDivideAssignment(lhs, rhs);
+                    case MODULO_EQUAL:
+                        return new ComplexModuloAssignment(lhs, rhs);
+                    case DEFAULT:
+                        return new AlternativeOperatorExpression(lhs, rhs);
+                    case OR:
+                        return new BooleanOrExpression(lhs, rhs);
+                    case AND:
+                        return new BooleanAndExpression(lhs, rhs);
+                    case LESS_EQUAL:
+                        return new CompareLessEqualTest(lhs, rhs);
+                    case LESS:
+                        return new CompareLessTest(lhs, rhs);
+                    case GREATER_EQUAL:
+                        return new CompareGreaterEqualTest(lhs, rhs);
+                    case GREATER:
+                        return new CompareGreaterTest(lhs, rhs);
+                    case EQUAL:
+                        return new CompareEqualTest(lhs, rhs);
+                    case NOT_EQUAL:
+                        return new CompareNotEqualTest(lhs, rhs);
+                    case PLUS:
+                        return new PlusExpression(lhs, rhs);
+                    case MINUS:
+                        return new MinusExpression(lhs, rhs);
+                    case MODULO:
+                        return new ModuloExpression(lhs, rhs);
+                    case DIVIDE:
+                        return new DivideExpression(lhs, rhs);
+                    case TIMES:
+                        return new MultiplyExpression(lhs, rhs);
+                    default:
+                        throw new IllegalStateException("Unknown operator: " + this);
+                }
 			} catch (Exception e) {
 				throw new RuntimeException(e);
 			}

--- a/jackson-jq/src/main/resources/META-INF/native-image/native-image.properties
+++ b/jackson-jq/src/main/resources/META-INF/native-image/native-image.properties
@@ -1,0 +1,1 @@
+Args=--initialize-at-build-time=org.jcodings.spi.Charsets,org.jcodings.spi.ISO_8859_16

--- a/jackson-jq/src/main/resources/META-INF/native-image/reflect-config.json
+++ b/jackson-jq/src/main/resources/META-INF/native-image/reflect-config.json
@@ -1,0 +1,57 @@
+[
+  {
+    "name": "net.thisptr.jackson.jq.internal.JqJson",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ],
+    "fields": [
+      {
+        "name": "functions"
+      }
+    ],
+    "condition": {
+      "typeReachable": "net.thisptr.jackson.jq.BuiltinFunctionLoader"
+    }
+  },
+  {
+    "name": "net.thisptr.jackson.jq.internal.JqJson$JqFuncDef",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ],
+    "fields": [
+      {
+        "name": "name"
+      },
+      {
+        "name": "args"
+      },
+      {
+        "name": "body"
+      },
+      {
+        "name": "version"
+      }
+    ],
+    "condition": {
+      "typeReachable": "net.thisptr.jackson.jq.internal.JqJson"
+    }
+  },
+  {
+    "name": "net.thisptr.jackson.jq.internal.misc.VersionRangeDeserializer",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ],
+    "condition": {
+      "typeReachable": "net.thisptr.jackson.jq.internal.JqJson$JqFuncDef"
+    }
+  }
+]

--- a/jackson-jq/src/main/resources/META-INF/native-image/reflect-config.json
+++ b/jackson-jq/src/main/resources/META-INF/native-image/reflect-config.json
@@ -1,57 +1,56 @@
 [
-  {
-    "name": "net.thisptr.jackson.jq.internal.JqJson",
-    "methods": [
-      {
-        "name": "<init>",
-        "parameterTypes": []
-      }
-    ],
-    "fields": [
-      {
-        "name": "functions"
-      }
-    ],
-    "condition": {
-      "typeReachable": "net.thisptr.jackson.jq.BuiltinFunctionLoader"
-    }
-  },
-  {
-    "name": "net.thisptr.jackson.jq.internal.JqJson$JqFuncDef",
-    "methods": [
-      {
-        "name": "<init>",
-        "parameterTypes": []
-      }
-    ],
-    "fields": [
-      {
-        "name": "name"
-      },
-      {
-        "name": "args"
-      },
-      {
-        "name": "body"
-      },
-      {
-        "name": "version"
-      }
-    ],
-    "condition": {
-      "typeReachable": "net.thisptr.jackson.jq.internal.JqJson"
-    }
-  },
-  {
-    "name": "net.thisptr.jackson.jq.internal.misc.VersionRangeDeserializer",
-    "methods": [
-      {
-        "name": "<init>",
-        "parameterTypes": []
-      }
-    ],
-    "condition": {
-      "typeReachable": "net.thisptr.jackson.jq.internal.JqJson$JqFuncDef"
-    }
-  }
+	{
+		"name": "net.thisptr.jackson.jq.internal.JqJson",
+		"allDeclaredFields": true,
+		"queryAllDeclaredMethods": true,
+		"queryAllDeclaredConstructors": true,
+		"methods": [
+			{
+				"name": "<init>",
+				"parameterTypes": []
+			}
+		],
+		"condition": {
+			"typeReachable": "net.thisptr.jackson.jq.BuiltinFunctionLoader"
+		}
+	},
+	{
+		"name": "net.thisptr.jackson.jq.internal.JqJson$JqFuncDef",
+		"allDeclaredFields": true,
+		"queryAllDeclaredMethods": true,
+		"queryAllDeclaredConstructors": true,
+		"methods": [
+			{
+				"name": "<init>",
+				"parameterTypes": []
+			}
+		],
+		"condition": {
+			"typeReachable": "net.thisptr.jackson.jq.internal.JqJson"
+		}
+	},
+	{
+		"name": "net.thisptr.jackson.jq.internal.functions._MatchImplFunction$CaptureObject",
+		"allDeclaredFields": true,
+		"queryAllDeclaredMethods": true,
+		"queryAllDeclaredConstructors": true
+	},
+	{
+		"name": "net.thisptr.jackson.jq.internal.functions._MatchImplFunction$MatchObject",
+		"allDeclaredFields": true,
+		"queryAllDeclaredMethods": true,
+		"queryAllDeclaredConstructors": true
+	},
+	{
+		"name": "net.thisptr.jackson.jq.internal.misc.VersionRangeDeserializer",
+		"methods": [
+			{
+				"name": "<init>",
+				"parameterTypes": []
+			}
+		],
+		"condition": {
+			"typeReachable": "net.thisptr.jackson.jq.internal.JqJson$JqFuncDef"
+		}
+	}
 ]

--- a/jackson-jq/src/main/resources/META-INF/native-image/resource-config.json
+++ b/jackson-jq/src/main/resources/META-INF/native-image/resource-config.json
@@ -1,0 +1,12 @@
+{
+  "resources": {
+    "includes": [
+      {
+        "condition": {
+          "typeReachable": "net.thisptr.jackson.jq.BuiltinFunctionLoader"
+        },
+        "pattern": "net/thisptr/jackson/jq/jq.json"
+      }
+    ]
+  }
+}

--- a/jackson-jq/src/main/resources/META-INF/native-image/resource-config.json
+++ b/jackson-jq/src/main/resources/META-INF/native-image/resource-config.json
@@ -1,12 +1,15 @@
 {
-  "resources": {
-    "includes": [
-      {
-        "condition": {
-          "typeReachable": "net.thisptr.jackson.jq.BuiltinFunctionLoader"
-        },
-        "pattern": "net/thisptr/jackson/jq/jq.json"
-      }
-    ]
-  }
+	"resources": {
+		"includes": [
+			{
+				"condition": {
+					"typeReachable": "net.thisptr.jackson.jq.BuiltinFunctionLoader"
+				},
+				"pattern": "net/thisptr/jackson/jq/jq.json"
+			},
+			{
+				"pattern": "tables/.*"
+			}
+		]
+	}
 }

--- a/jackson-jq/src/test/java/net/thisptr/jackson/jq/ClassLoaderUtils.java
+++ b/jackson-jq/src/test/java/net/thisptr/jackson/jq/ClassLoaderUtils.java
@@ -1,0 +1,55 @@
+package net.thisptr.jackson.jq;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URL;
+import java.nio.file.FileSystem;
+import java.nio.file.FileSystems;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.Objects;
+import java.util.function.BiConsumer;
+import java.util.stream.Stream;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class ClassLoaderUtils {
+	private static final Logger log = LoggerFactory.getLogger(ClassLoaderUtils.class);
+
+	public static final FileSystem fileSystem = createFileSystem();
+
+	private static FileSystem createFileSystem() {
+		// This hack registers NativeImageResourceFileSystem when ran via Native Image
+		// https://github.com/oracle/graal/issues/7682
+		try {
+			FileSystem fileSystem = FileSystems.newFileSystem(
+				URI.create("resource:/"),
+				Collections.singletonMap("create", "true")
+			);
+			Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+				try {
+					fileSystem.close();
+				} catch (IOException e) {
+					throw new RuntimeException(e);
+				}
+			}));
+			return fileSystem;
+		} catch (Exception e) {
+			log.info("Not running in native image, skipping");
+		}
+		return FileSystems.getDefault();
+	}
+
+	public static Path resolve(String fileName) {
+		URL url = ClassLoaderUtils.class.getClassLoader().getResource(fileName);
+		return fileSystem.getPath(Objects.requireNonNull(url).getPath());
+	}
+
+	public static void walk(String basePath, BiConsumer<Path, Path> onWalk) throws IOException {
+		Path path = resolve(basePath);
+		try (Stream<Path> walk = Files.walk(path)) {
+			walk.forEach(p -> onWalk.accept(p, path.relativize(p)));
+		}
+	}
+}

--- a/jackson-jq/src/test/java/net/thisptr/jackson/jq/JsonQueryTest.java
+++ b/jackson-jq/src/test/java/net/thisptr/jackson/jq/JsonQueryTest.java
@@ -1,7 +1,6 @@
 package net.thisptr.jackson.jq;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assumptions.assumeThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
@@ -32,6 +31,7 @@ import net.thisptr.jackson.jq.test.evaluator.Evaluator;
 import net.thisptr.jackson.jq.test.evaluator.Evaluator.Result;
 import net.thisptr.jackson.jq.test.evaluator.TrueJqEvaluator;
 import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -161,10 +161,14 @@ public class JsonQueryTest {
 
 		if (!tc.ignoreTrueJqBehavior && hasJqCache.computeIfAbsent(version, v -> TrueJqEvaluator.hasJq(v))) {
 			final Result result = cachedJqEvaluator.evaluate(tc.q, tc.in, version, 2000L);
-			assumeThat(result.error).as("%s", command).isNull();
-			assumeThat(tc.out).as("%s", command)
+			try {
+                assertThat(result.error).as("%s", command).isNull();
+				assertThat(tc.out).as("%s", command)
 					.usingElementComparator(comparator)
 					.isEqualTo(result.values);
+			} catch (AssertionError e) {
+				Assumptions.abort(String.format("Assumption failed: %s %s", command, e));
+			}
 		}
 
 		boolean failed = false;
@@ -202,7 +206,7 @@ public class JsonQueryTest {
 			assertThat(failed).describedAs("The test case is marked as failing but completed successfully").isTrue();
 	}
 
-	@ParameterizedTest
+    @ParameterizedTest
 	@MethodSource("defaultTestCases")
 	public void test(final String tcText) throws Throwable {
 		final TestCase tc = JSON_MAPPER.readValue(tcText, TestCase.class);

--- a/jackson-jq/src/test/java/net/thisptr/jackson/jq/JsonQueryTest.java
+++ b/jackson-jq/src/test/java/net/thisptr/jackson/jq/JsonQueryTest.java
@@ -4,21 +4,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assumptions.assumeThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import java.io.IOException;
-import java.io.InputStream;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Comparator;
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.stream.Stream;
-
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.MethodSource;
-
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
@@ -29,15 +14,27 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
 import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
-import com.google.common.reflect.ClassPath;
-import com.google.common.reflect.ClassPath.ResourceInfo;
-
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Stream;
 import net.thisptr.jackson.jq.exception.JsonQueryException;
 import net.thisptr.jackson.jq.internal.misc.VersionRangeDeserializer;
 import net.thisptr.jackson.jq.test.evaluator.CachedEvaluator;
 import net.thisptr.jackson.jq.test.evaluator.Evaluator;
 import net.thisptr.jackson.jq.test.evaluator.Evaluator.Result;
 import net.thisptr.jackson.jq.test.evaluator.TrueJqEvaluator;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 public class JsonQueryTest {
 	private static final ObjectMapper JSON_MAPPER = new ObjectMapper();
@@ -84,9 +81,10 @@ public class JsonQueryTest {
 		}
 	}
 
-	private static List<TestCase> loadTestCases(final ClassLoader classLoader, final String resourceName, final boolean failing) throws Throwable {
+	private static List<TestCase> loadTestCases(final Path path, final boolean failing) throws IOException {
 		final TestCase[] result;
-		try (InputStream in = classLoader.getResourceAsStream(resourceName)) {
+		try (InputStream in = Files.newInputStream(path)) {
+			String resourceName = path.toString();
 			if (resourceName.endsWith(".yaml")) {
 				result = YAML_MAPPER.readValue(in, TestCase[].class);
 			} else if (resourceName.endsWith(".json")) {
@@ -103,31 +101,29 @@ public class JsonQueryTest {
 		return Arrays.asList(result);
 	}
 
-	private static List<TestCase> loadTestCasesDirectory(final ClassLoader classLoader, final String directory, final boolean failing) throws Throwable {
+	private static List<TestCase> loadTestCasesDirectory(final String directory, final boolean failing) throws IOException {
 		final List<TestCase> testCases = new ArrayList<>();
-		final ClassPath classPath = ClassPath.from(classLoader);
-		for (final ResourceInfo resource : classPath.getResources()) {
-			final String name = resource.getResourceName();
-			if (!name.startsWith(directory))
-				continue;
-			if (!name.endsWith(".json") && !name.endsWith(".yaml"))
-				continue;
-			try {
-				testCases.addAll(loadTestCases(classLoader, name, failing));
-			} catch (final Throwable e) {
-				throw new RuntimeException("Failed to load " + name, e);
+		ClassLoaderUtils.walk(directory, (path, relativePath) -> {
+			if (Files.isDirectory(path)) {
+				return;
 			}
-		}
+			String name = relativePath.toString();
+			if (name.endsWith(".json") || name.endsWith(".yaml")) {
+				try {
+					testCases.addAll(loadTestCases(path, failing));
+				} catch (final Throwable e) {
+					throw new RuntimeException("Failed to load " + relativePath, e);
+				}
+			}
+		});
 		return testCases;
 	}
 
-	static Stream<String> defaultTestCases() throws Throwable {
-		final ClassLoader classLoader = JsonQueryTest.class.getClassLoader();
-
+	static Stream<String> defaultTestCases() throws IOException {
 		final List<TestCase> testCases = new ArrayList<>();
-		testCases.addAll(loadTestCases(classLoader, "jq-test-extra-ok.json", false));
-		testCases.addAll(loadTestCasesDirectory(classLoader, "tests", false));
-		testCases.addAll(loadTestCasesDirectory(classLoader, "failing_tests", true));
+		testCases.addAll(loadTestCases(ClassLoaderUtils.resolve("jq-test-extra-ok.json"), false));
+		testCases.addAll(loadTestCasesDirectory("tests", false));
+		testCases.addAll(loadTestCasesDirectory("failing_tests", true));
 
 		return testCases.stream().map(a -> {
 			try {

--- a/jackson-jq/src/test/java/net/thisptr/jackson/jq/module/loaders/FileSystemModuleLoaderTest.java
+++ b/jackson-jq/src/test/java/net/thisptr/jackson/jq/module/loaders/FileSystemModuleLoaderTest.java
@@ -3,36 +3,64 @@ package net.thisptr.jackson.jq.module.loaders;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import java.net.URISyntaxException;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.IntNode;
 import com.fasterxml.jackson.databind.node.NullNode;
-
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import net.thisptr.jackson.jq.ClassLoaderUtils;
 import net.thisptr.jackson.jq.JsonQuery;
 import net.thisptr.jackson.jq.Scope;
 import net.thisptr.jackson.jq.Versions;
 import net.thisptr.jackson.jq.module.ModuleLoader;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class FileSystemModuleLoaderTest {
+	private static final Logger log = LoggerFactory.getLogger(FileSystemModuleLoaderTest.class);
+
 	private Scope rootScope;
 
+	@TempDir
+	private Path tempDir;
+
 	@BeforeEach
-	public void beforeEach() throws URISyntaxException {
+	public void beforeEach() throws IOException {
 		rootScope = Scope.newEmptyScope();
 
-		final Path searchPath = Paths.get(FileSystemModuleLoaderTest.class.getClassLoader().getResource("classpath_modules").toURI());
-		final ModuleLoader moduleLoader = new FileSystemModuleLoader(rootScope, Versions.JQ_1_6, searchPath);
+		final ModuleLoader moduleLoader = setupModuleLoader(tempDir);
 
 		rootScope.setModuleLoader(moduleLoader);
+	}
+
+	/**
+	 * Copy modules from classpath to temporary directory.
+	 * <p>
+	 *	This is required for native image as the module loader reads from an absolute directory,
+	 *	while in native image we get test resources in classpath referenced by resource:/[resource-uri]
+	 * </p>
+	 */
+	private ModuleLoader setupModuleLoader(Path tempDir) throws IOException {
+		ClassLoaderUtils.walk("classpath_modules", (src, relativePath) -> {
+			try {
+				Path dest = tempDir.resolve(relativePath.toString());
+				if (Files.isDirectory(src)) {
+					Files.createDirectories(dest);
+				} else {
+					Files.copy(src, dest);
+				}
+			} catch (IOException e) {
+				throw new RuntimeException(e);
+			}
+		});
+		return new FileSystemModuleLoader(rootScope, Versions.JQ_1_6, tempDir);
 	}
 
 	@Test

--- a/jackson-jq/src/test/resources/META-INF/native-image/reflect-config.json
+++ b/jackson-jq/src/test/resources/META-INF/native-image/reflect-config.json
@@ -15,6 +15,30 @@
 		}
 	},
 	{
+		"name": "net.thisptr.jackson.jq.test.evaluator.CachedEvaluator$Key",
+		"allDeclaredFields": true,
+		"queryAllDeclaredMethods": true,
+		"queryAllDeclaredConstructors": true,
+		"condition": {
+			"typeReachable": "net.thisptr.jackson.jq.test.evaluator.CachedEvaluator"
+		}
+	},
+	{
+		"name": "net.thisptr.jackson.jq.test.evaluator.CachedEvaluator$Value",
+		"allDeclaredFields": true,
+		"queryAllDeclaredMethods": true,
+		"queryAllDeclaredConstructors": true,
+		"methods": [
+			{
+				"name": "<init>",
+				"parameterTypes": []
+			}
+		],
+		"condition": {
+			"typeReachable": "net.thisptr.jackson.jq.test.evaluator.CachedEvaluator"
+		}
+	},
+	{
 		"name": "com.fasterxml.jackson.databind.ser.std.ToStringSerializer",
 		"methods": [
 			{

--- a/jackson-jq/src/test/resources/META-INF/native-image/reflect-config.json
+++ b/jackson-jq/src/test/resources/META-INF/native-image/reflect-config.json
@@ -1,0 +1,29 @@
+[
+	{
+		"name": "net.thisptr.jackson.jq.JsonQueryTest$TestCase",
+		"allDeclaredFields": true,
+		"queryAllDeclaredMethods": true,
+		"queryAllDeclaredConstructors": true,
+		"methods": [
+			{
+				"name": "<init>",
+				"parameterTypes": []
+			}
+		],
+		"condition": {
+			"typeReachable": "net.thisptr.jackson.jq.JsonQueryTest"
+		}
+	},
+	{
+		"name": "com.fasterxml.jackson.databind.ser.std.ToStringSerializer",
+		"methods": [
+			{
+				"name": "<init>",
+				"parameterTypes": []
+			}
+		],
+		"condition": {
+			"typeReachable": "net.thisptr.jackson.jq.JsonQueryTest"
+		}
+	}
+]

--- a/pom.xml
+++ b/pom.xml
@@ -72,10 +72,6 @@
 
 	<dependencies>
 		<dependency>
-			<groupId>com.fasterxml.jackson.core</groupId>
-			<artifactId>jackson-databind</artifactId>
-		</dependency>
-		<dependency>
 			<groupId>org.junit.jupiter</groupId>
 			<artifactId>junit-jupiter-api</artifactId>
 			<scope>test</scope>


### PR DESCRIPTION
Closes #484 

This initial support adds the following:
* `BinaryOperatorExpression` to not use reflection
* `resource-config.json` file to be included for reading functions from `jq.json`
* `reflect-config.json` file to be included for jackson to use reflection to parse the `jq.json` file
* Added `native-image.properties` because of static initialisation by joni library
* Included native-image tests and related resources
* Included `tables/.*` to be used by Joni libraries
* Included all entites using jackson serialisers / deserialisers in reflect-config.json

Haven't tested the same, but ideally the new functions should also be included with the given `ServiceLoader` as the current methods from `ServiceLoader` and the methods from `jq.json` files are being included.