### PR TITLE
chore: Upgrade to Jackson 3.x and to Java 17

### DIFF
--- a/.github/workflows/test-pull-requests.yaml
+++ b/.github/workflows/test-pull-requests.yaml
@@ -9,8 +9,8 @@ jobs:
     strategy:
       matrix:
         java-env:
-          - name: "JDK 1.8"
-            java-version: "8"
+          - name: "JDK 17"
+            java-version: "17"
             distribution: "temurin"
             maven-command: "mvn clean package"
           - name: "GraalVM 21"
@@ -21,8 +21,8 @@ jobs:
     steps:
     - uses: actions/checkout@v5.0.0
     
-    - name: Set up JDK 1.8
-      if: matrix.java-env.name == 'JDK 1.8'
+    - name: Set up JDK 17
+      if: matrix.java-env.name == 'JDK 17'
       uses: actions/setup-java@v5.0.0
       with:
         java-version: ${{ matrix.java-env.java-version }}

--- a/jackson-jq-cli/src/main/java/net/thisptr/jackson/jq/cli/Main.java
+++ b/jackson-jq-cli/src/main/java/net/thisptr/jackson/jq/cli/Main.java
@@ -17,10 +17,11 @@ import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
 
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializationFeature;
+import tools.jackson.core.JsonParser;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.SerializationFeature;
+import tools.jackson.databind.json.JsonMapper;
 
 import net.thisptr.jackson.jq.BuiltinFunctionLoader;
 import net.thisptr.jackson.jq.JsonQuery;
@@ -36,8 +37,14 @@ import net.thisptr.jackson.jq.module.loaders.ChainedModuleLoader;
 import net.thisptr.jackson.jq.module.loaders.FileSystemModuleLoader;
 
 public class Main {
-	private static final ObjectMapper MAPPER = new ObjectMapper()
-			.registerModule(JsonQueryJacksonModule.getInstance());
+	private static final ObjectMapper COMPACT_MAPPER = JsonMapper.builder()
+			.addModule(JsonQueryJacksonModule.getInstance())
+			.build();
+
+	private static final ObjectMapper PRETTY_MAPPER = JsonMapper.builder()
+			.addModule(JsonQueryJacksonModule.getInstance())
+			.enable(SerializationFeature.INDENT_OUTPUT)
+			.build();
 
 	private static final Option OPT_COMPACT = Option.builder("c")
 			.longOpt("compact")
@@ -102,9 +109,7 @@ public class Main {
 
 		final JsonQuery jq = JsonQuery.compile(rest.get(0), version);
 
-		if (!command.hasOption(OPT_COMPACT.getOpt())) {
-			MAPPER.enable(SerializationFeature.INDENT_OUTPUT);
-		}
+		final ObjectMapper mapper = command.hasOption(OPT_COMPACT.getOpt()) ? COMPACT_MAPPER : PRETTY_MAPPER;
 
 		InputStream is = System.in;
 		if (command.hasOption(OPT_NULL_INPUT.getOpt())) {
@@ -121,21 +126,17 @@ public class Main {
 		}));
 
 		try (final BufferedReader reader = new BufferedReader(new InputStreamReader(is))) {
-			final JsonParser parser = MAPPER.getFactory().createParser(reader);
+			final JsonParser parser = mapper.createParser(reader);
 			while (!parser.isClosed()) {
 				final JsonNode tree = parser.readValueAsTree();
 				if (tree == null)
 					continue;
 				try {
 					jq.apply(scope, tree, (out) -> {
-						if (out.isTextual() && command.hasOption(OPT_RAW_OUTPUT.getOpt())) {
-							System.out.println(out.asText());
+						if (out.isString() && command.hasOption(OPT_RAW_OUTPUT.getOpt())) {
+							System.out.println(out.asString());
 						} else {
-							try {
-								System.out.println(MAPPER.writeValueAsString(out));
-							} catch (IOException e) {
-								throw new RuntimeException(e);
-							}
+							System.out.println(mapper.writeValueAsString(out));
 						}
 					});
 				} catch (JsonQueryException e) {

--- a/jackson-jq-extra/src/main/java/net/thisptr/jackson/jq/extra/functions/HostnameFunction.java
+++ b/jackson-jq-extra/src/main/java/net/thisptr/jackson/jq/extra/functions/HostnameFunction.java
@@ -3,9 +3,9 @@ package net.thisptr.jackson.jq.extra.functions;
 import java.net.InetAddress;
 import java.util.List;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.NullNode;
-import com.fasterxml.jackson.databind.node.TextNode;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.node.NullNode;
+import tools.jackson.databind.node.StringNode;
 import com.google.auto.service.AutoService;
 
 import net.thisptr.jackson.jq.BuiltinFunction;
@@ -26,8 +26,8 @@ public class HostnameFunction implements Function {
 	public HostnameFunction() {
 		try {
 			final InetAddress addr = InetAddress.getLocalHost();
-			this.hostname = new TextNode(addr.getHostName());
-			this.fqdn = new TextNode(addr.getCanonicalHostName());
+			this.hostname = new StringNode(addr.getHostName());
+			this.fqdn = new StringNode(addr.getCanonicalHostName());
 		} catch (Exception e) {
 			/* ignore */
 		}
@@ -37,7 +37,7 @@ public class HostnameFunction implements Function {
 	public void apply(final Scope scope, final List<Expression> args, final JsonNode in, final Path ipath, final PathOutput output, final Version version) throws JsonQueryException {
 		if (args.size() == 1) {
 			args.get(0).apply(scope, in, (arg) -> {
-				if (arg.isTextual() && "fqdn".equals(arg.asText())) {
+				if (arg.isString() && "fqdn".equals(arg.asString())) {
 					output.emit(fqdn, null);
 				} else {
 					output.emit(hostname, null);

--- a/jackson-jq-extra/src/main/java/net/thisptr/jackson/jq/extra/functions/RandomFunction.java
+++ b/jackson-jq-extra/src/main/java/net/thisptr/jackson/jq/extra/functions/RandomFunction.java
@@ -2,8 +2,8 @@ package net.thisptr.jackson.jq.extra.functions;
 
 import java.util.List;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.DoubleNode;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.node.DoubleNode;
 import com.google.auto.service.AutoService;
 
 import net.thisptr.jackson.jq.BuiltinFunction;

--- a/jackson-jq-extra/src/main/java/net/thisptr/jackson/jq/extra/functions/StrFTimeFunction.java
+++ b/jackson-jq-extra/src/main/java/net/thisptr/jackson/jq/extra/functions/StrFTimeFunction.java
@@ -4,9 +4,9 @@ import java.text.SimpleDateFormat;
 import java.util.List;
 import java.util.TimeZone;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.JsonNodeType;
-import com.fasterxml.jackson.databind.node.TextNode;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.node.JsonNodeType;
+import tools.jackson.databind.node.StringNode;
 import com.google.auto.service.AutoService;
 
 import net.thisptr.jackson.jq.BuiltinFunction;
@@ -29,18 +29,18 @@ public class StrFTimeFunction implements Function {
 
 		try {
 			args.get(0).apply(scope, in, (fmt) -> {
-				if (!fmt.isTextual())
+				if (!fmt.isString())
 					throw new JsonQueryTypeException("Illegal argument type: %s", fmt.getNodeType());
-				final SimpleDateFormat sdf = new SimpleDateFormat(fmt.asText());
+				final SimpleDateFormat sdf = new SimpleDateFormat(fmt.asString());
 				if (args.size() == 2) {
 					args.get(1).apply(scope, in, (tz) -> {
-						if (!tz.isTextual())
+						if (!tz.isString())
 							throw new JsonQueryTypeException("Timezone must be a string");
-						sdf.setTimeZone(TimeZone.getTimeZone(tz.asText()));
-						output.emit(new TextNode(sdf.format((long) in.asDouble())), null);
+						sdf.setTimeZone(TimeZone.getTimeZone(tz.asString()));
+						output.emit(new StringNode(sdf.format((long) in.asDouble())), null);
 					});
 				} else {
-					output.emit(new TextNode(sdf.format((long) in.asDouble())), null);
+					output.emit(new StringNode(sdf.format((long) in.asDouble())), null);
 				}
 			});
 		} catch (Exception e) {

--- a/jackson-jq-extra/src/main/java/net/thisptr/jackson/jq/extra/functions/StrPTimeFunction.java
+++ b/jackson-jq-extra/src/main/java/net/thisptr/jackson/jq/extra/functions/StrPTimeFunction.java
@@ -5,9 +5,9 @@ import java.text.SimpleDateFormat;
 import java.util.List;
 import java.util.TimeZone;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.JsonNodeType;
-import com.fasterxml.jackson.databind.node.LongNode;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.node.JsonNodeType;
+import tools.jackson.databind.node.LongNode;
 import com.google.auto.service.AutoService;
 
 import net.thisptr.jackson.jq.BuiltinFunction;
@@ -30,23 +30,23 @@ public class StrPTimeFunction implements Function {
 
 		try {
 			args.get(0).apply(scope, in, (fmt) -> {
-				if (!fmt.isTextual())
+				if (!fmt.isString())
 					throw new JsonQueryTypeException("Illegal argument type: %s", fmt.getNodeType());
-				final SimpleDateFormat sdf = new SimpleDateFormat(fmt.asText());
+				final SimpleDateFormat sdf = new SimpleDateFormat(fmt.asString());
 				if (args.size() == 2) {
 					args.get(1).apply(scope, in, (tz) -> {
-						if (!tz.isTextual())
+						if (!tz.isString())
 							throw new JsonQueryTypeException("Timezone must be a string");
-						sdf.setTimeZone(TimeZone.getTimeZone(tz.asText()));
+						sdf.setTimeZone(TimeZone.getTimeZone(tz.asString()));
 						try {
-							output.emit(new LongNode(sdf.parse(in.asText()).getTime()), null);
+							output.emit(new LongNode(sdf.parse(in.asString()).getTime()), null);
 						} catch (ParseException e) {
 							throw new JsonQueryException(e);
 						}
 					});
 				} else {
 					try {
-						output.emit(new LongNode(sdf.parse(in.asText()).getTime()), null);
+						output.emit(new LongNode(sdf.parse(in.asString()).getTime()), null);
 					} catch (ParseException e) {
 						throw new JsonQueryException(e);
 					}

--- a/jackson-jq-extra/src/main/java/net/thisptr/jackson/jq/extra/functions/TimestampFunction.java
+++ b/jackson-jq-extra/src/main/java/net/thisptr/jackson/jq/extra/functions/TimestampFunction.java
@@ -2,8 +2,8 @@ package net.thisptr.jackson.jq.extra.functions;
 
 import java.util.List;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.LongNode;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.node.LongNode;
 import com.google.auto.service.AutoService;
 
 import net.thisptr.jackson.jq.BuiltinFunction;

--- a/jackson-jq-extra/src/main/java/net/thisptr/jackson/jq/extra/functions/UriDecodeFunction.java
+++ b/jackson-jq-extra/src/main/java/net/thisptr/jackson/jq/extra/functions/UriDecodeFunction.java
@@ -4,9 +4,9 @@ import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
 import java.util.List;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.JsonNodeType;
-import com.fasterxml.jackson.databind.node.TextNode;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.node.JsonNodeType;
+import tools.jackson.databind.node.StringNode;
 import com.google.auto.service.AutoService;
 
 import net.thisptr.jackson.jq.BuiltinFunction;
@@ -27,7 +27,7 @@ public class UriDecodeFunction implements Function {
 		Preconditions.checkInputType("urldecode", in, JsonNodeType.STRING);
 
 		try {
-			output.emit(new TextNode(URLDecoder.decode(in.asText(), "UTF-8")), null);
+			output.emit(new StringNode(URLDecoder.decode(in.asString(), "UTF-8")), null);
 		} catch (UnsupportedEncodingException e) {
 			throw new JsonQueryException(e);
 		}

--- a/jackson-jq-extra/src/main/java/net/thisptr/jackson/jq/extra/functions/UriParseFunction.java
+++ b/jackson-jq-extra/src/main/java/net/thisptr/jackson/jq/extra/functions/UriParseFunction.java
@@ -12,10 +12,10 @@ import java.util.regex.Pattern;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.ArrayNode;
-import com.fasterxml.jackson.databind.node.JsonNodeType;
-import com.fasterxml.jackson.databind.node.TextNode;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.node.ArrayNode;
+import tools.jackson.databind.node.JsonNodeType;
+import tools.jackson.databind.node.StringNode;
 import com.google.auto.service.AutoService;
 
 import net.thisptr.jackson.jq.BuiltinFunction;
@@ -118,10 +118,10 @@ public class UriParseFunction implements Function {
 			if (entry.getValue().size() > 1) {
 				final ArrayNode arr = scope.getObjectMapper().createArrayNode();
 				for (final String value : entry.getValue())
-					arr.add(new TextNode(value));
+					arr.add(new StringNode(value));
 				result2.put(entry.getKey(), arr);
 			} else {
-				result2.put(entry.getKey(), new TextNode(entry.getValue().get(0)));
+				result2.put(entry.getKey(), new StringNode(entry.getValue().get(0)));
 			}
 		}
 		return result2;
@@ -132,7 +132,7 @@ public class UriParseFunction implements Function {
 		Preconditions.checkInputType("uriparse", in, JsonNodeType.STRING);
 
 		try {
-			final URI uri = new URI(in.asText());
+			final URI uri = new URI(in.asString());
 			final Result result = new Result(uri, parseQueryObj(scope, uri.getRawQuery()));
 			output.emit(scope.getObjectMapper().valueToTree(result), null);
 		} catch (URISyntaxException e) {

--- a/jackson-jq-extra/src/main/java/net/thisptr/jackson/jq/extra/functions/Uuid35Function.java
+++ b/jackson-jq-extra/src/main/java/net/thisptr/jackson/jq/extra/functions/Uuid35Function.java
@@ -1,13 +1,12 @@
 package net.thisptr.jackson.jq.extra.functions;
 
-import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.UUID;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.JsonNodeType;
-import com.fasterxml.jackson.databind.node.TextNode;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.node.JsonNodeType;
+import tools.jackson.databind.node.StringNode;
 import net.thisptr.jackson.jq.Expression;
 import net.thisptr.jackson.jq.Function;
 import net.thisptr.jackson.jq.PathOutput;
@@ -31,27 +30,23 @@ public class Uuid35Function implements Function {
 		Preconditions.checkInputType("uuid5", in, JsonNodeType.STRING, JsonNodeType.BINARY);
 
 		args.get(0).apply(scope, in, (namespaceArg) -> {
-			if (!namespaceArg.isTextual())
+			if (!namespaceArg.isString())
 				throw new JsonQueryTypeException("namespace must be string, but got: %s", namespaceArg.getNodeType());
 			UUID namespace;
 			try {
-				namespace = UUID.fromString(namespaceArg.asText());
+				namespace = UUID.fromString(namespaceArg.asString());
 			} catch (IllegalArgumentException e) {
 				throw new JsonQueryException("namespace must be a valid UUID", e);
 			}
 
 			UUID uuid;
 			if (in.isBinary()) {
-				try {
-					uuid = UuidUtils.uuid3or5(namespace, in.binaryValue(), this.uuidVersion);
-				} catch (IOException e) {
-					throw new JsonQueryException(e);
-				}
+				uuid = UuidUtils.uuid3or5(namespace, in.binaryValue(), this.uuidVersion);
 			} else {
-				uuid = UuidUtils.uuid3or5(namespace, in.asText().getBytes(StandardCharsets.UTF_8), this.uuidVersion);
+				uuid = UuidUtils.uuid3or5(namespace, in.asString().getBytes(StandardCharsets.UTF_8), this.uuidVersion);
 			}
 
-			output.emit(new TextNode(uuid.toString()), null);
+			output.emit(new StringNode(uuid.toString()), null);
 		});
 	}
 }

--- a/jackson-jq-extra/src/main/java/net/thisptr/jackson/jq/extra/functions/Uuid4Function.java
+++ b/jackson-jq-extra/src/main/java/net/thisptr/jackson/jq/extra/functions/Uuid4Function.java
@@ -3,8 +3,8 @@ package net.thisptr.jackson.jq.extra.functions;
 import java.util.List;
 import java.util.UUID;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.TextNode;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.node.StringNode;
 import com.google.auto.service.AutoService;
 
 import net.thisptr.jackson.jq.BuiltinFunction;
@@ -21,6 +21,6 @@ import net.thisptr.jackson.jq.path.Path;
 public class Uuid4Function implements Function {
 	@Override
 	public void apply(final Scope scope, final List<Expression> args, final JsonNode in, final Path ipath, final PathOutput output, final Version version) throws JsonQueryException {
-		output.emit(new TextNode(UUID.randomUUID().toString()), null);
+		output.emit(new StringNode(UUID.randomUUID().toString()), null);
 	}
 }

--- a/jackson-jq-extra/src/main/java/net/thisptr/jackson/jq/extra/internal/misc/Preconditions.java
+++ b/jackson-jq-extra/src/main/java/net/thisptr/jackson/jq/extra/internal/misc/Preconditions.java
@@ -2,8 +2,8 @@ package net.thisptr.jackson.jq.extra.internal.misc;
 
 import java.util.Arrays;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.JsonNodeType;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.node.JsonNodeType;
 
 import net.thisptr.jackson.jq.exception.IllegalJsonInputException;
 

--- a/jackson-jq-extra/src/test/java/net/thisptr/jackson/jq/extra/TestUtils.java
+++ b/jackson-jq-extra/src/test/java/net/thisptr/jackson/jq/extra/TestUtils.java
@@ -3,7 +3,7 @@ package net.thisptr.jackson.jq.extra;
 import java.util.ArrayList;
 import java.util.List;
 
-import com.fasterxml.jackson.databind.JsonNode;
+import tools.jackson.databind.JsonNode;
 import net.thisptr.jackson.jq.JsonQuery;
 import net.thisptr.jackson.jq.Scope;
 import net.thisptr.jackson.jq.Version;

--- a/jackson-jq-extra/src/test/java/net/thisptr/jackson/jq/extra/functions/UriParseFunctionTest.java
+++ b/jackson-jq-extra/src/test/java/net/thisptr/jackson/jq/extra/functions/UriParseFunctionTest.java
@@ -4,7 +4,7 @@ import java.util.Collections;
 
 import org.junit.jupiter.api.Test;
 
-import com.fasterxml.jackson.databind.node.TextNode;
+import tools.jackson.databind.node.StringNode;
 
 import net.thisptr.jackson.jq.BuiltinFunctionLoader;
 import net.thisptr.jackson.jq.Expression;
@@ -18,6 +18,6 @@ public class UriParseFunctionTest {
 		final Scope scope = Scope.newEmptyScope();
 		BuiltinFunctionLoader.getInstance().loadFunctions(Versions.JQ_1_5, scope);
 		// check this does not throw NPE
-		new UriParseFunction().apply(scope, Collections.<Expression>emptyList(), new TextNode("http://google.com"), null, (out, opath) -> {}, Versions.JQ_1_5);
+		new UriParseFunction().apply(scope, Collections.<Expression>emptyList(), new StringNode("http://google.com"), null, (out, opath) -> {}, Versions.JQ_1_5);
 	}
 }

--- a/jackson-jq-extra/src/test/java/net/thisptr/jackson/jq/extra/functions/Uuid35FunctionTest.java
+++ b/jackson-jq-extra/src/test/java/net/thisptr/jackson/jq/extra/functions/Uuid35FunctionTest.java
@@ -3,9 +3,9 @@ package net.thisptr.jackson.jq.extra.functions;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.BinaryNode;
-import com.fasterxml.jackson.databind.node.TextNode;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.node.BinaryNode;
+import tools.jackson.databind.node.StringNode;
 import net.thisptr.jackson.jq.Versions;
 import net.thisptr.jackson.jq.exception.JsonQueryException;
 import net.thisptr.jackson.jq.extra.TestUtils;
@@ -17,20 +17,20 @@ public class Uuid35FunctionTest {
 
 	@Test
 	public void testUuid3() throws JsonQueryException {
-		List<JsonNode> results = TestUtils.runQuery("extras::uuid3(\"6ba7b810-9dad-11d1-80b4-00c04fd430c8\")", TextNode.valueOf("example.com"), Versions.JQ_1_6);
-		assertThat(results).containsExactly(TextNode.valueOf("9073926b-929f-31c2-abc9-fad77ae3e8eb"));
+		List<JsonNode> results = TestUtils.runQuery("extras::uuid3(\"6ba7b810-9dad-11d1-80b4-00c04fd430c8\")", StringNode.valueOf("example.com"), Versions.JQ_1_6);
+		assertThat(results).containsExactly(StringNode.valueOf("9073926b-929f-31c2-abc9-fad77ae3e8eb"));
 	}
 
 	@Test
 	public void testUuid5() throws JsonQueryException {
-		List<JsonNode> results = TestUtils.runQuery("extras::uuid5(\"6ba7b810-9dad-11d1-80b4-00c04fd430c8\")", TextNode.valueOf("example.com"), Versions.JQ_1_6);
-		assertThat(results).containsExactly(TextNode.valueOf("cfbff0d1-9375-5685-968c-48ce8b15ae17"));
+		List<JsonNode> results = TestUtils.runQuery("extras::uuid5(\"6ba7b810-9dad-11d1-80b4-00c04fd430c8\")", StringNode.valueOf("example.com"), Versions.JQ_1_6);
+		assertThat(results).containsExactly(StringNode.valueOf("cfbff0d1-9375-5685-968c-48ce8b15ae17"));
 	}
 
 	@Test
 	public void testUuid5WithBinaryInput() throws JsonQueryException {
 		JsonNode in = BinaryNode.valueOf("example.com".getBytes(StandardCharsets.UTF_8));
 		List<JsonNode> results = TestUtils.runQuery("extras::uuid5(\"6ba7b810-9dad-11d1-80b4-00c04fd430c8\")", in, Versions.JQ_1_6);
-		assertThat(results).containsExactly(TextNode.valueOf("cfbff0d1-9375-5685-968c-48ce8b15ae17"));
+		assertThat(results).containsExactly(StringNode.valueOf("cfbff0d1-9375-5685-968c-48ce8b15ae17"));
 	}
 }

--- a/jackson-jq/pom.xml
+++ b/jackson-jq/pom.xml
@@ -17,7 +17,7 @@
 			<artifactId>jackson-annotations</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>com.fasterxml.jackson.core</groupId>
+			<groupId>tools.jackson.core</groupId>
 			<artifactId>jackson-databind</artifactId>
 		</dependency>
 		<dependency>
@@ -32,7 +32,7 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
-			<groupId>com.fasterxml.jackson.dataformat</groupId>
+			<groupId>tools.jackson.dataformat</groupId>
 			<artifactId>jackson-dataformat-yaml</artifactId>
 			<scope>test</scope>
 		</dependency>

--- a/jackson-jq/src/main/java/net/thisptr/jackson/jq/BuiltinFunctionLoader.java
+++ b/jackson-jq/src/main/java/net/thisptr/jackson/jq/BuiltinFunctionLoader.java
@@ -12,8 +12,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.ServiceLoader;
 
-import com.fasterxml.jackson.databind.MappingIterator;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.MappingIterator;
+import tools.jackson.databind.ObjectMapper;
 
 import net.thisptr.jackson.jq.internal.IsolatedScopeQuery;
 import net.thisptr.jackson.jq.internal.JqJson;
@@ -85,7 +85,7 @@ public class BuiltinFunctionLoader {
 					buffer.append('\n');
 				}
 			}
-			final MappingIterator<JqJson> iter2 = DEFAULT_MAPPER.readValues(DEFAULT_MAPPER.getFactory().createParser(buffer.toString()), JqJson.class);
+			final MappingIterator<JqJson> iter2 = DEFAULT_MAPPER.readValues(DEFAULT_MAPPER.createParser(buffer.toString()), JqJson.class);
 			while (iter2.hasNext()) {
 				result.add(iter2.next());
 			}

--- a/jackson-jq/src/main/java/net/thisptr/jackson/jq/Expression.java
+++ b/jackson-jq/src/main/java/net/thisptr/jackson/jq/Expression.java
@@ -1,6 +1,6 @@
 package net.thisptr.jackson.jq;
 
-import com.fasterxml.jackson.databind.JsonNode;
+import tools.jackson.databind.JsonNode;
 
 import net.thisptr.jackson.jq.exception.JsonQueryException;
 import net.thisptr.jackson.jq.path.Path;

--- a/jackson-jq/src/main/java/net/thisptr/jackson/jq/Function.java
+++ b/jackson-jq/src/main/java/net/thisptr/jackson/jq/Function.java
@@ -2,7 +2,7 @@ package net.thisptr.jackson.jq;
 
 import java.util.List;
 
-import com.fasterxml.jackson.databind.JsonNode;
+import tools.jackson.databind.JsonNode;
 
 import net.thisptr.jackson.jq.exception.JsonQueryException;
 import net.thisptr.jackson.jq.path.Path;

--- a/jackson-jq/src/main/java/net/thisptr/jackson/jq/JsonQuery.java
+++ b/jackson-jq/src/main/java/net/thisptr/jackson/jq/JsonQuery.java
@@ -1,6 +1,6 @@
 package net.thisptr.jackson.jq;
 
-import com.fasterxml.jackson.databind.JsonNode;
+import tools.jackson.databind.JsonNode;
 
 import net.thisptr.jackson.jq.exception.JsonQueryException;
 import net.thisptr.jackson.jq.internal.IsolatedScopeQuery;

--- a/jackson-jq/src/main/java/net/thisptr/jackson/jq/Output.java
+++ b/jackson-jq/src/main/java/net/thisptr/jackson/jq/Output.java
@@ -1,6 +1,6 @@
 package net.thisptr.jackson.jq;
 
-import com.fasterxml.jackson.databind.JsonNode;
+import tools.jackson.databind.JsonNode;
 
 import net.thisptr.jackson.jq.exception.JsonQueryException;
 import net.thisptr.jackson.jq.path.Path;

--- a/jackson-jq/src/main/java/net/thisptr/jackson/jq/PathOutput.java
+++ b/jackson-jq/src/main/java/net/thisptr/jackson/jq/PathOutput.java
@@ -1,6 +1,6 @@
 package net.thisptr.jackson.jq;
 
-import com.fasterxml.jackson.databind.JsonNode;
+import tools.jackson.databind.JsonNode;
 
 import net.thisptr.jackson.jq.exception.JsonQueryException;
 import net.thisptr.jackson.jq.path.Path;

--- a/jackson-jq/src/main/java/net/thisptr/jackson/jq/Scope.java
+++ b/jackson-jq/src/main/java/net/thisptr/jackson/jq/Scope.java
@@ -11,8 +11,9 @@ import java.util.function.Supplier;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
 
 import net.thisptr.jackson.jq.internal.annotations.Experimental;
 import net.thisptr.jackson.jq.internal.misc.JsonQueryJacksonModule;
@@ -22,8 +23,9 @@ import net.thisptr.jackson.jq.module.ModuleLoader;
 import net.thisptr.jackson.jq.path.Path;
 
 public class Scope {
-	private static final ObjectMapper DEFAULT_MAPPER = new ObjectMapper()
-			.registerModule(JsonQueryJacksonModule.getInstance());
+	private static final ObjectMapper DEFAULT_MAPPER = JsonMapper.builder()
+			.addModule(JsonQueryJacksonModule.getInstance())
+			.build();
 
 	@JsonProperty("functions")
 	private Map<String, String> debugFunctions() {

--- a/jackson-jq/src/main/java/net/thisptr/jackson/jq/exception/JsonQueryBreakException.java
+++ b/jackson-jq/src/main/java/net/thisptr/jackson/jq/exception/JsonQueryBreakException.java
@@ -1,9 +1,9 @@
 package net.thisptr.jackson.jq.exception;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.IntNode;
-import com.fasterxml.jackson.databind.node.ObjectNode;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.node.IntNode;
+import tools.jackson.databind.node.ObjectNode;
 
 public class JsonQueryBreakException extends JsonQueryException {
 	private static final long serialVersionUID = -6066878919494380889L;

--- a/jackson-jq/src/main/java/net/thisptr/jackson/jq/exception/JsonQueryException.java
+++ b/jackson-jq/src/main/java/net/thisptr/jackson/jq/exception/JsonQueryException.java
@@ -1,14 +1,14 @@
 package net.thisptr.jackson.jq.exception;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.JsonNodeType;
-import com.fasterxml.jackson.databind.node.TextNode;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.node.JsonNodeType;
+import tools.jackson.databind.node.StringNode;
 
 import net.thisptr.jackson.jq.internal.misc.JsonNodeUtils;
 import net.thisptr.jackson.jq.internal.misc.Strings;
 
-public class JsonQueryException extends JsonProcessingException {
+public class JsonQueryException extends JacksonException {
 	private static final long serialVersionUID = -7241258446595502920L;
 
 	public JsonQueryException(final String msg) {
@@ -24,7 +24,7 @@ public class JsonQueryException extends JsonProcessingException {
 	}
 
 	public JsonNode getMessageAsJsonNode() {
-		return new TextNode(getMessage());
+		return new StringNode(getMessage());
 	}
 
 	public JsonQueryException(final String format, final Object... args) {

--- a/jackson-jq/src/main/java/net/thisptr/jackson/jq/exception/JsonQueryUserException.java
+++ b/jackson-jq/src/main/java/net/thisptr/jackson/jq/exception/JsonQueryUserException.java
@@ -1,6 +1,6 @@
 package net.thisptr.jackson.jq.exception;
 
-import com.fasterxml.jackson.databind.JsonNode;
+import tools.jackson.databind.JsonNode;
 
 import net.thisptr.jackson.jq.internal.misc.JsonNodeUtils;
 
@@ -10,7 +10,7 @@ public class JsonQueryUserException extends JsonQueryException {
 	private JsonNode value;
 
 	public JsonQueryUserException(final JsonNode value) {
-		super(value.isTextual() ? value.asText() : JsonNodeUtils.toString(value));
+		super(value.isString() ? value.asString() : JsonNodeUtils.toString(value));
 		this.value = value;
 	}
 

--- a/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/FixedScopeQuery.java
+++ b/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/FixedScopeQuery.java
@@ -1,6 +1,6 @@
 package net.thisptr.jackson.jq.internal;
 
-import com.fasterxml.jackson.databind.JsonNode;
+import tools.jackson.databind.JsonNode;
 
 import net.thisptr.jackson.jq.Expression;
 import net.thisptr.jackson.jq.PathOutput;

--- a/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/IsolatedScopeQuery.java
+++ b/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/IsolatedScopeQuery.java
@@ -1,6 +1,6 @@
 package net.thisptr.jackson.jq.internal;
 
-import com.fasterxml.jackson.databind.JsonNode;
+import tools.jackson.databind.JsonNode;
 
 import net.thisptr.jackson.jq.Expression;
 import net.thisptr.jackson.jq.PathOutput;

--- a/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/JqJson.java
+++ b/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/JqJson.java
@@ -5,7 +5,7 @@ import java.util.List;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import tools.jackson.databind.annotation.JsonDeserialize;
 
 import net.thisptr.jackson.jq.VersionRange;
 import net.thisptr.jackson.jq.internal.annotations.InterfaceAudience;

--- a/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/JsonArgumentFunction.java
+++ b/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/JsonArgumentFunction.java
@@ -4,7 +4,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Stack;
 
-import com.fasterxml.jackson.databind.JsonNode;
+import tools.jackson.databind.JsonNode;
 
 import net.thisptr.jackson.jq.Expression;
 import net.thisptr.jackson.jq.Function;

--- a/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/JsonNodeFunction.java
+++ b/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/JsonNodeFunction.java
@@ -2,7 +2,7 @@ package net.thisptr.jackson.jq.internal;
 
 import java.util.List;
 
-import com.fasterxml.jackson.databind.JsonNode;
+import tools.jackson.databind.JsonNode;
 
 import net.thisptr.jackson.jq.Expression;
 import net.thisptr.jackson.jq.Function;

--- a/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/JsonPredicateFunction.java
+++ b/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/JsonPredicateFunction.java
@@ -3,8 +3,8 @@ package net.thisptr.jackson.jq.internal;
 import java.util.List;
 import java.util.function.Predicate;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.BooleanNode;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.node.BooleanNode;
 
 import net.thisptr.jackson.jq.Expression;
 import net.thisptr.jackson.jq.Function;

--- a/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/JsonQueryFunction.java
+++ b/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/JsonQueryFunction.java
@@ -3,7 +3,7 @@ package net.thisptr.jackson.jq.internal;
 import java.util.Collections;
 import java.util.List;
 
-import com.fasterxml.jackson.databind.JsonNode;
+import tools.jackson.databind.JsonNode;
 
 import net.thisptr.jackson.jq.Expression;
 import net.thisptr.jackson.jq.Function;

--- a/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/filters/AbstractSvFilter.java
+++ b/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/filters/AbstractSvFilter.java
@@ -2,9 +2,9 @@ package net.thisptr.jackson.jq.internal.filters;
 
 import java.util.List;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.TextNode;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.node.StringNode;
 
 import net.thisptr.jackson.jq.Expression;
 import net.thisptr.jackson.jq.Function;
@@ -34,14 +34,14 @@ public abstract class AbstractSvFilter implements Function {
 			if (!heading)
 				appendSeparator(row);
 
-			if (col.isTextual()) {
-				appendEscaped(row, col.asText());
+			if (col.isString()) {
+				appendEscaped(row, col.asString());
 			} else if (col.isNull() || col.isNumber() && Double.isNaN(col.asDouble())) {
 				// empty
 			} else if (col.isBoolean() || col.isNumber()) {
 				try {
 					row.append(scope.getObjectMapper().writeValueAsString(col));
-				} catch (JsonProcessingException e) {
+				} catch (JacksonException e) {
 					throw new JsonQueryException(e);
 				}
 			} else {
@@ -51,6 +51,6 @@ public abstract class AbstractSvFilter implements Function {
 			heading = false;
 		}
 
-		output.emit(TextNode.valueOf(row.toString()), null);
+		output.emit(StringNode.valueOf(row.toString()), null);
 	}
 }

--- a/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/functions/AbstractAtFormattingFunction.java
+++ b/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/functions/AbstractAtFormattingFunction.java
@@ -2,9 +2,9 @@ package net.thisptr.jackson.jq.internal.functions;
 
 import java.util.List;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.TextNode;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.node.StringNode;
 
 import net.thisptr.jackson.jq.Expression;
 import net.thisptr.jackson.jq.Function;
@@ -20,11 +20,11 @@ public abstract class AbstractAtFormattingFunction implements Function {
 	public void apply(final Scope scope, final List<Expression> args, final JsonNode in, final Path ipath, final PathOutput output, final Version version) throws JsonQueryException {
 		final String text;
 		try {
-			text = in.isTextual() ? in.asText() : scope.getObjectMapper().writeValueAsString(in);
-		} catch (JsonProcessingException e) {
+			text = in.isString() ? in.asString() : scope.getObjectMapper().writeValueAsString(in);
+		} catch (JacksonException e) {
 			throw new JsonQueryException(e);
 		}
-		output.emit(new TextNode(convert(text)), null);
+		output.emit(new StringNode(convert(text)), null);
 	}
 
 	public abstract String convert(String text) throws JsonQueryException;

--- a/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/functions/AbstractKeysFunction.java
+++ b/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/functions/AbstractKeysFunction.java
@@ -3,11 +3,11 @@ package net.thisptr.jackson.jq.internal.functions;
 import java.util.Collections;
 import java.util.List;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.ArrayNode;
-import com.fasterxml.jackson.databind.node.IntNode;
-import com.fasterxml.jackson.databind.node.JsonNodeType;
-import com.fasterxml.jackson.databind.node.TextNode;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.node.ArrayNode;
+import tools.jackson.databind.node.IntNode;
+import tools.jackson.databind.node.JsonNodeType;
+import tools.jackson.databind.node.StringNode;
 
 import net.thisptr.jackson.jq.Expression;
 import net.thisptr.jackson.jq.Function;
@@ -33,13 +33,13 @@ public class AbstractKeysFunction implements Function {
 		Preconditions.checkInputType(name, in, JsonNodeType.OBJECT, JsonNodeType.ARRAY);
 
 		if (in.isObject()) {
-			final List<String> keys = Lists.newArrayList(in.fieldNames());
+			final List<String> keys = Lists.newArrayList(in.propertyNames());
 			if (sortKeys)
 				Collections.sort(keys);
 
 			final ArrayNode result = scope.getObjectMapper().createArrayNode();
 			for (final String key : keys)
-				result.add(new TextNode(key));
+				result.add(new StringNode(key));
 			output.emit(result, null);
 		} else if (in.isArray()) {
 			final ArrayNode result = scope.getObjectMapper().createArrayNode();

--- a/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/functions/AbstractMaxByFunction.java
+++ b/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/functions/AbstractMaxByFunction.java
@@ -2,10 +2,10 @@ package net.thisptr.jackson.jq.internal.functions;
 
 import java.util.List;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.ArrayNode;
-import com.fasterxml.jackson.databind.node.JsonNodeType;
-import com.fasterxml.jackson.databind.node.NullNode;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.node.ArrayNode;
+import tools.jackson.databind.node.JsonNodeType;
+import tools.jackson.databind.node.NullNode;
 
 import net.thisptr.jackson.jq.Expression;
 import net.thisptr.jackson.jq.Function;

--- a/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/functions/AbstractStartsEndsWithFunction.java
+++ b/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/functions/AbstractStartsEndsWithFunction.java
@@ -2,8 +2,8 @@ package net.thisptr.jackson.jq.internal.functions;
 
 import java.util.List;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.BooleanNode;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.node.BooleanNode;
 
 import net.thisptr.jackson.jq.Expression;
 import net.thisptr.jackson.jq.Function;
@@ -25,9 +25,9 @@ public abstract class AbstractStartsEndsWithFunction implements Function {
 	@Override
 	public void apply(final Scope scope, final List<Expression> args, final JsonNode in, final Path ipath, final PathOutput output, final Version version) throws JsonQueryException {
 		args.get(0).apply(scope, in, (needle) -> {
-			if (!needle.isTextual() || !in.isTextual())
+			if (!needle.isString() || !in.isString())
 				throw new JsonQueryException(fname + "() requires string inputs");
-			output.emit(BooleanNode.valueOf(doCheck(in.asText(), needle.asText())), null);
+			output.emit(BooleanNode.valueOf(doCheck(in.asString(), needle.asString())), null);
 		});
 	}
 }

--- a/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/functions/AbstractTrimStrFunction.java
+++ b/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/functions/AbstractTrimStrFunction.java
@@ -2,8 +2,8 @@ package net.thisptr.jackson.jq.internal.functions;
 
 import java.util.List;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.TextNode;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.node.StringNode;
 
 import net.thisptr.jackson.jq.Expression;
 import net.thisptr.jackson.jq.Function;
@@ -18,11 +18,11 @@ public abstract class AbstractTrimStrFunction implements Function {
 	@Override
 	public void apply(final Scope scope, final List<Expression> args, final JsonNode in, final Path ipath, final PathOutput output, final Version version) throws JsonQueryException {
 		args.get(0).apply(scope, in, (trimText) -> {
-			if (!in.isTextual() || !trimText.isTextual()) {
+			if (!in.isString() || !trimText.isString()) {
 				output.emit(in, ipath);
 				return;
 			}
-			final JsonNode out = TextNode.valueOf(doTrim(in.asText(), trimText.asText()));
+			final JsonNode out = StringNode.valueOf(doTrim(in.asString(), trimText.asString()));
 			output.emit(out, null);
 		});
 	}

--- a/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/functions/AtBase64dFunction.java
+++ b/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/functions/AtBase64dFunction.java
@@ -3,7 +3,7 @@ package net.thisptr.jackson.jq.internal.functions;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 
-import com.fasterxml.jackson.databind.node.TextNode;
+import tools.jackson.databind.node.StringNode;
 import com.google.auto.service.AutoService;
 
 import net.thisptr.jackson.jq.BuiltinFunction;
@@ -18,7 +18,7 @@ public class AtBase64dFunction extends AbstractAtFormattingFunction {
 		try {
 			return new String(Base64.getDecoder().decode(text), StandardCharsets.UTF_8);
 		} catch (final Throwable th) {
-			throw new JsonQueryException("%s is not valid base64 data: %s", TextNode.valueOf(text), th.getMessage());
+			throw new JsonQueryException("%s is not valid base64 data: %s", StringNode.valueOf(text), th.getMessage());
 		}
 	}
 }

--- a/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/functions/AtShFunction.java
+++ b/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/functions/AtShFunction.java
@@ -3,9 +3,9 @@ package net.thisptr.jackson.jq.internal.functions;
 import java.util.ArrayList;
 import java.util.List;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.TextNode;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.node.StringNode;
 import com.google.auto.service.AutoService;
 
 import net.thisptr.jackson.jq.BuiltinFunction;
@@ -27,19 +27,19 @@ public class AtShFunction implements Function {
 		if (in.isArray()) {
 			final List<String> tokens = new ArrayList<>();
 			for (final JsonNode i : in) {
-				if (i.isTextual()) {
-					tokens.add(escape(i.asText()));
+				if (i.isString()) {
+					tokens.add(escape(i.asString()));
 				} else if (i.isValueNode()) {
 					tokens.add(toString(scope, i));
 				} else {
 					throw new IllegalJsonInputException(i.getNodeType() + " cannot be escaped for shell");
 				}
 			}
-			output.emit(new TextNode(Strings.join(" ", tokens)), null);
-		} else if (in.isTextual()) {
-			output.emit(new TextNode(escape(in.asText())), null);
+			output.emit(new StringNode(Strings.join(" ", tokens)), null);
+		} else if (in.isString()) {
+			output.emit(new StringNode(escape(in.asString())), null);
 		} else if (in.isValueNode()) {
-			output.emit(new TextNode(toString(scope, in)), null);
+			output.emit(new StringNode(toString(scope, in)), null);
 		} else {
 			throw new IllegalJsonInputException(in.getNodeType() + " cannot be escaped for shell");
 		}
@@ -48,7 +48,7 @@ public class AtShFunction implements Function {
 	private static String toString(final Scope scope, final JsonNode node) throws JsonQueryException {
 		try {
 			return scope.getObjectMapper().writeValueAsString(node);
-		} catch (final JsonProcessingException e) {
+		} catch (final JacksonException e) {
 			throw new JsonQueryException(e);
 		}
 	}

--- a/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/functions/BuiltinsFunction.java
+++ b/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/functions/BuiltinsFunction.java
@@ -4,7 +4,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-import com.fasterxml.jackson.databind.JsonNode;
+import tools.jackson.databind.JsonNode;
 import com.google.auto.service.AutoService;
 
 import net.thisptr.jackson.jq.BuiltinFunction;

--- a/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/functions/ContainsFunction.java
+++ b/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/functions/ContainsFunction.java
@@ -1,11 +1,10 @@
 package net.thisptr.jackson.jq.internal.functions;
 
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map.Entry;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.BooleanNode;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.node.BooleanNode;
 import com.google.auto.service.AutoService;
 
 import net.thisptr.jackson.jq.BuiltinFunction;
@@ -36,8 +35,8 @@ public class ContainsFunction implements Function {
 	}
 
 	private static boolean contains(final JsonNode needle, final JsonNode haystack) {
-		if (haystack.isTextual() && needle.isTextual()) {
-			return haystack.asText().contains(needle.asText());
+		if (haystack.isString() && needle.isString()) {
+			return haystack.asString().contains(needle.asString());
 		} else if (haystack.isArray() && needle.isArray()) {
 			for (final JsonNode n : needle) {
 				boolean found = false;
@@ -52,9 +51,7 @@ public class ContainsFunction implements Function {
 			}
 			return true;
 		} else if (haystack.isObject() && needle.isObject()) {
-			final Iterator<Entry<String, JsonNode>> iter = needle.fields();
-			while (iter.hasNext()) {
-				final Entry<String, JsonNode> field = iter.next();
+			for (final Entry<String, JsonNode> field : needle.properties()) {
 				final JsonNode tmp = haystack.get(field.getKey());
 				if (tmp == null)
 					return false;

--- a/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/functions/DelPathsFunction.java
+++ b/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/functions/DelPathsFunction.java
@@ -3,9 +3,9 @@ package net.thisptr.jackson.jq.internal.functions;
 import java.util.ArrayList;
 import java.util.List;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.ArrayNode;
-import com.fasterxml.jackson.databind.node.MissingNode;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.node.ArrayNode;
+import tools.jackson.databind.node.MissingNode;
 import com.google.auto.service.AutoService;
 
 import net.thisptr.jackson.jq.BuiltinFunction;

--- a/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/functions/EmptyFunction.java
+++ b/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/functions/EmptyFunction.java
@@ -2,7 +2,7 @@ package net.thisptr.jackson.jq.internal.functions;
 
 import java.util.List;
 
-import com.fasterxml.jackson.databind.JsonNode;
+import tools.jackson.databind.JsonNode;
 import com.google.auto.service.AutoService;
 
 import net.thisptr.jackson.jq.BuiltinFunction;

--- a/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/functions/EnvFunction.java
+++ b/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/functions/EnvFunction.java
@@ -2,8 +2,8 @@ package net.thisptr.jackson.jq.internal.functions;
 
 import java.util.List;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
 
 import net.thisptr.jackson.jq.BuiltinFunction;
 import net.thisptr.jackson.jq.Expression;

--- a/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/functions/ErrorFunction.java
+++ b/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/functions/ErrorFunction.java
@@ -2,7 +2,7 @@ package net.thisptr.jackson.jq.internal.functions;
 
 import java.util.List;
 
-import com.fasterxml.jackson.databind.JsonNode;
+import tools.jackson.databind.JsonNode;
 import com.google.auto.service.AutoService;
 
 import net.thisptr.jackson.jq.BuiltinFunction;

--- a/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/functions/ExplodeFunction.java
+++ b/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/functions/ExplodeFunction.java
@@ -2,9 +2,9 @@ package net.thisptr.jackson.jq.internal.functions;
 
 import java.util.List;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.ArrayNode;
-import com.fasterxml.jackson.databind.node.JsonNodeType;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.node.ArrayNode;
+import tools.jackson.databind.node.JsonNodeType;
 import com.google.auto.service.AutoService;
 
 import net.thisptr.jackson.jq.BuiltinFunction;
@@ -25,7 +25,7 @@ public class ExplodeFunction implements Function {
 		Preconditions.checkInputType("explode", in, JsonNodeType.STRING);
 
 		final ArrayNode result = scope.getObjectMapper().createArrayNode();
-		for (final int ch : in.asText().codePoints().toArray())
+		for (final int ch : in.asString().codePoints().toArray())
 			result.add(ch);
 		output.emit(result, null);
 	}

--- a/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/functions/FromDateIso8601Function.java
+++ b/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/functions/FromDateIso8601Function.java
@@ -1,7 +1,7 @@
 package net.thisptr.jackson.jq.internal.functions;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.JsonNodeType;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.node.JsonNodeType;
 import com.google.auto.service.AutoService;
 import net.thisptr.jackson.jq.*;
 import net.thisptr.jackson.jq.exception.JsonQueryException;
@@ -20,7 +20,7 @@ public class FromDateIso8601Function implements Function {
     public void apply(final Scope scope, final List<Expression> args, final JsonNode in, final Path ipath, final PathOutput output, final Version version) throws JsonQueryException {
         Preconditions.checkInputType("fromdateiso8601", in, JsonNodeType.STRING);
         try {
-            String iso8601String = in.asText();
+            String iso8601String = in.asString();
             // In future versions of JQ, it may need to be revisited due to fractional support: https://github.com/jqlang/jq/issues/1409
             if (iso8601String.length() > 20) {
                 throw new JsonQueryException(String.format("date \"%s\" does not match format \"%%Y-%%m-%%dT%%H:%%M:%%SZ\"", iso8601String));

--- a/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/functions/FromEntriesFunction.java
+++ b/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/functions/FromEntriesFunction.java
@@ -2,9 +2,9 @@ package net.thisptr.jackson.jq.internal.functions;
 
 import java.util.List;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.NullNode;
-import com.fasterxml.jackson.databind.node.ObjectNode;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.node.NullNode;
+import tools.jackson.databind.node.ObjectNode;
 import com.google.auto.service.AutoService;
 
 import net.thisptr.jackson.jq.BuiltinFunction;
@@ -37,14 +37,14 @@ public class FromEntriesFunction implements Function {
 				key = entry.get("name");
 			if (key == null)
 				key = entry.get("Name");
-			if (key == null || !key.isTextual())
+			if (key == null || !key.isString())
 				throw new JsonQueryTypeException("Cannot use %s as object key", key == null ? NullNode.getInstance() : key);
 
 			JsonNode value = entry.get("value");
 			if (value == null)
 				value = entry.get("Value");
 
-			out.set(key.asText(), value == null ? NullNode.getInstance() : value);
+			out.set(key.asString(), value == null ? NullNode.getInstance() : value);
 		}
 
 		output.emit(out, null);

--- a/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/functions/FromJsonFunction.java
+++ b/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/functions/FromJsonFunction.java
@@ -1,10 +1,11 @@
 package net.thisptr.jackson.jq.internal.functions;
 
-import java.io.IOException;
 import java.util.List;
 
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.databind.JsonNode;
+import tools.jackson.core.JsonParser;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
 import com.google.auto.service.AutoService;
 
 import net.thisptr.jackson.jq.BuiltinFunction;
@@ -22,11 +23,12 @@ import net.thisptr.jackson.jq.path.Path;
 public class FromJsonFunction implements Function {
 	@Override
 	public void apply(final Scope scope, final List<Expression> args, final JsonNode in, final Path ipath, final PathOutput output, final Version version) throws JsonQueryException {
-		if (!in.isTextual())
+		if (!in.isString())
 			throw new JsonQueryTypeException("%s only strings can be parsed", in);
 
 		final JsonNode tree;
-		try (final JsonParser parser = scope.getObjectMapper().getFactory().createParser(in.asText())) {
+		final ObjectMapper mapper = scope.getObjectMapper();
+		try (final JsonParser parser = mapper.createParser(in.asString())) {
 			tree = parser.readValueAsTree();
 			if (tree == null)
 				throw new JsonQueryException("failed to parse %s as json; empty", in);
@@ -34,7 +36,7 @@ public class FromJsonFunction implements Function {
 				throw new JsonQueryException("failed to parse %s as json; trailing data", in);
 		} catch (final JsonQueryException e) {
 			throw e;
-		} catch (final IOException e) {
+		} catch (final JacksonException e) {
 			throw new JsonQueryException("failed to parse %s as json", in);
 		}
 		output.emit(tree, null);

--- a/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/functions/GetPathFunction.java
+++ b/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/functions/GetPathFunction.java
@@ -2,7 +2,7 @@ package net.thisptr.jackson.jq.internal.functions;
 
 import java.util.List;
 
-import com.fasterxml.jackson.databind.JsonNode;
+import tools.jackson.databind.JsonNode;
 import com.google.auto.service.AutoService;
 
 import net.thisptr.jackson.jq.BuiltinFunction;

--- a/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/functions/GroupByFunction.java
+++ b/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/functions/GroupByFunction.java
@@ -4,8 +4,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.TreeMap;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.JsonNodeType;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.node.JsonNodeType;
 import com.google.auto.service.AutoService;
 
 import net.thisptr.jackson.jq.BuiltinFunction;

--- a/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/functions/HasFunction.java
+++ b/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/functions/HasFunction.java
@@ -2,8 +2,8 @@ package net.thisptr.jackson.jq.internal.functions;
 
 import java.util.List;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.BooleanNode;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.node.BooleanNode;
 import com.google.auto.service.AutoService;
 
 import net.thisptr.jackson.jq.BuiltinFunction;
@@ -26,9 +26,9 @@ public class HasFunction implements Function {
 		}
 		args.get(0).apply(scope, in, (keyName) -> {
 			if (in.isObject()) {
-				if (!keyName.isTextual())
+				if (!keyName.isString())
 					throw new JsonQueryException("argument 1 of has() must be string for object input");
-				output.emit(BooleanNode.valueOf(in.has(keyName.asText())), null);
+				output.emit(BooleanNode.valueOf(in.has(keyName.asString())), null);
 			} else if (in.isArray()) {
 				if (!keyName.isIntegralNumber())
 					throw new JsonQueryException("argument 1 of has() must be int for array input");

--- a/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/functions/ImplodeFunction.java
+++ b/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/functions/ImplodeFunction.java
@@ -2,9 +2,9 @@ package net.thisptr.jackson.jq.internal.functions;
 
 import java.util.List;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.JsonNodeType;
-import com.fasterxml.jackson.databind.node.TextNode;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.node.JsonNodeType;
+import tools.jackson.databind.node.StringNode;
 import com.google.auto.service.AutoService;
 
 import net.thisptr.jackson.jq.BuiltinFunction;
@@ -33,6 +33,6 @@ public class ImplodeFunction implements Function {
 			}
 		}
 
-		output.emit(new TextNode(builder.toString()), null);
+		output.emit(new StringNode(builder.toString()), null);
 	}
 }

--- a/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/functions/IndexFunction.java
+++ b/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/functions/IndexFunction.java
@@ -2,9 +2,9 @@ package net.thisptr.jackson.jq.internal.functions;
 
 import java.util.List;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.IntNode;
-import com.fasterxml.jackson.databind.node.NullNode;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.node.IntNode;
+import tools.jackson.databind.node.NullNode;
 import com.google.auto.service.AutoService;
 
 import net.thisptr.jackson.jq.BuiltinFunction;

--- a/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/functions/IndicesFunction.java
+++ b/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/functions/IndicesFunction.java
@@ -3,10 +3,10 @@ package net.thisptr.jackson.jq.internal.functions;
 import java.util.ArrayList;
 import java.util.List;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.ArrayNode;
-import com.fasterxml.jackson.databind.node.JsonNodeType;
-import com.fasterxml.jackson.databind.node.NullNode;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.node.ArrayNode;
+import tools.jackson.databind.node.JsonNodeType;
+import tools.jackson.databind.node.NullNode;
 import com.google.auto.service.AutoService;
 
 import net.thisptr.jackson.jq.BuiltinFunction;
@@ -44,9 +44,9 @@ public class IndicesFunction implements Function {
 
 	public static List<Integer> indices(final JsonNode needle, final JsonNode haystack) throws JsonQueryException {
 		final List<Integer> result = new ArrayList<>();
-		if (needle.isTextual() && haystack.isTextual()) {
-			final String haystackText = haystack.asText();
-			final String needleText = needle.asText();
+		if (needle.isString() && haystack.isString()) {
+			final String haystackText = haystack.asString();
+			final String needleText = needle.asString();
 			if (!needleText.isEmpty()) {
 				for (int index = haystackText.indexOf(needleText); index >= 0; index = haystackText.indexOf(needleText, index + 1))
 					result.add(index);

--- a/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/functions/InfiniteFunction.java
+++ b/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/functions/InfiniteFunction.java
@@ -1,6 +1,6 @@
 package net.thisptr.jackson.jq.internal.functions;
 
-import com.fasterxml.jackson.databind.node.DoubleNode;
+import tools.jackson.databind.node.DoubleNode;
 import com.google.auto.service.AutoService;
 
 import net.thisptr.jackson.jq.BuiltinFunction;

--- a/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/functions/IsInfiniteFunction.java
+++ b/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/functions/IsInfiniteFunction.java
@@ -1,6 +1,6 @@
 package net.thisptr.jackson.jq.internal.functions;
 
-import com.fasterxml.jackson.databind.JsonNode;
+import tools.jackson.databind.JsonNode;
 import com.google.auto.service.AutoService;
 
 import net.thisptr.jackson.jq.BuiltinFunction;

--- a/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/functions/IsNanFunction.java
+++ b/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/functions/IsNanFunction.java
@@ -1,6 +1,6 @@
 package net.thisptr.jackson.jq.internal.functions;
 
-import com.fasterxml.jackson.databind.JsonNode;
+import tools.jackson.databind.JsonNode;
 import com.google.auto.service.AutoService;
 
 import net.thisptr.jackson.jq.BuiltinFunction;

--- a/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/functions/IsNormalFunction.java
+++ b/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/functions/IsNormalFunction.java
@@ -1,6 +1,6 @@
 package net.thisptr.jackson.jq.internal.functions;
 
-import com.fasterxml.jackson.databind.JsonNode;
+import tools.jackson.databind.JsonNode;
 import com.google.auto.service.AutoService;
 
 import net.thisptr.jackson.jq.BuiltinFunction;

--- a/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/functions/JoinFunction.java
+++ b/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/functions/JoinFunction.java
@@ -2,8 +2,8 @@ package net.thisptr.jackson.jq.internal.functions;
 
 import java.util.List;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.TextNode;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.node.StringNode;
 import com.google.auto.service.AutoService;
 
 import net.thisptr.jackson.jq.BuiltinFunction;
@@ -30,17 +30,17 @@ public class JoinFunction implements Function {
 			final StringBuilder builder = new StringBuilder();
 			for (final JsonNode item : in) {
 				if (isep != null) {
-					if (isep.isTextual()) {
-						builder.append(isep.asText());
+					if (isep.isString()) {
+						builder.append(isep.asString());
 					} else if (isep.isNull()) {
 						// append nothing
 					} else {
-						throw new JsonQueryTypeException("%s and %s cannot be added", new TextNode(builder.toString()), isep);
+						throw new JsonQueryTypeException("%s and %s cannot be added", new StringNode(builder.toString()), isep);
 					}
 				}
 
-				if (item.isTextual()) {
-					builder.append(item.asText());
+				if (item.isString()) {
+					builder.append(item.asString());
 				} else if (item.isNull()) {
 					// append nothing
 				} else if (version.compareTo(Versions.JQ_1_6) >= 0 && (item.isNumber() || item.isBoolean())) {
@@ -49,13 +49,13 @@ public class JoinFunction implements Function {
 					builder.append(item.toString());
 				} else {
 					if (version.compareTo(Versions.JQ_1_6) >= 0)
-						throw new JsonQueryTypeException("%s and %s cannot be added", new TextNode(builder.toString()), item);
+						throw new JsonQueryTypeException("%s and %s cannot be added", new StringNode(builder.toString()), item);
 					throw new JsonQueryTypeException("%s and %s cannot be added", sep, item);
 				}
 
 				isep = sep;
 			}
-			output.emit(new TextNode(builder.toString()), null);
+			output.emit(new StringNode(builder.toString()), null);
 		});
 	}
 }

--- a/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/functions/LengthFunction.java
+++ b/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/functions/LengthFunction.java
@@ -2,8 +2,8 @@ package net.thisptr.jackson.jq.internal.functions;
 
 import java.util.List;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.IntNode;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.node.IntNode;
 import com.google.auto.service.AutoService;
 
 import net.thisptr.jackson.jq.BuiltinFunction;
@@ -27,8 +27,8 @@ public class LengthFunction implements Function {
 	}
 
 	public JsonNode length(final JsonNode in) throws JsonQueryException {
-		if (in.isTextual()) {
-			return IntNode.valueOf(UnicodeUtils.lengthUtf32(in.asText()));
+		if (in.isString()) {
+			return IntNode.valueOf(UnicodeUtils.lengthUtf32(in.asString()));
 		} else if (in.isArray() || in.isObject()) {
 			return new IntNode(in.size());
 		} else if (in.isNull()) {

--- a/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/functions/MathFunction.java
+++ b/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/functions/MathFunction.java
@@ -2,9 +2,9 @@ package net.thisptr.jackson.jq.internal.functions;
 
 import java.util.List;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.DoubleNode;
-import com.fasterxml.jackson.databind.node.JsonNodeType;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.node.DoubleNode;
+import tools.jackson.databind.node.JsonNodeType;
 import com.google.auto.service.AutoService;
 
 import net.thisptr.jackson.jq.BuiltinFunction;

--- a/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/functions/MaxByFunction.java
+++ b/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/functions/MaxByFunction.java
@@ -1,6 +1,6 @@
 package net.thisptr.jackson.jq.internal.functions;
 
-import com.fasterxml.jackson.databind.JsonNode;
+import tools.jackson.databind.JsonNode;
 import com.google.auto.service.AutoService;
 
 import net.thisptr.jackson.jq.BuiltinFunction;

--- a/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/functions/MinByFunction.java
+++ b/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/functions/MinByFunction.java
@@ -1,6 +1,6 @@
 package net.thisptr.jackson.jq.internal.functions;
 
-import com.fasterxml.jackson.databind.JsonNode;
+import tools.jackson.databind.JsonNode;
 import com.google.auto.service.AutoService;
 
 import net.thisptr.jackson.jq.BuiltinFunction;

--- a/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/functions/NanFunction.java
+++ b/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/functions/NanFunction.java
@@ -1,6 +1,6 @@
 package net.thisptr.jackson.jq.internal.functions;
 
-import com.fasterxml.jackson.databind.node.DoubleNode;
+import tools.jackson.databind.node.DoubleNode;
 import com.google.auto.service.AutoService;
 
 import net.thisptr.jackson.jq.BuiltinFunction;

--- a/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/functions/NotFunction.java
+++ b/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/functions/NotFunction.java
@@ -2,8 +2,8 @@ package net.thisptr.jackson.jq.internal.functions;
 
 import java.util.List;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.BooleanNode;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.node.BooleanNode;
 import com.google.auto.service.AutoService;
 
 import net.thisptr.jackson.jq.BuiltinFunction;

--- a/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/functions/NowFunction.java
+++ b/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/functions/NowFunction.java
@@ -2,8 +2,8 @@ package net.thisptr.jackson.jq.internal.functions;
 
 import java.util.List;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.DoubleNode;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.node.DoubleNode;
 import com.google.auto.service.AutoService;
 
 import net.thisptr.jackson.jq.BuiltinFunction;

--- a/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/functions/PathFunction.java
+++ b/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/functions/PathFunction.java
@@ -2,9 +2,9 @@ package net.thisptr.jackson.jq.internal.functions;
 
 import java.util.List;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.ArrayNode;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.node.ArrayNode;
 import com.google.auto.service.AutoService;
 
 import net.thisptr.jackson.jq.BuiltinFunction;

--- a/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/functions/PathsFunction.java
+++ b/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/functions/PathsFunction.java
@@ -1,13 +1,12 @@
 package net.thisptr.jackson.jq.internal.functions;
 
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map.Entry;
 import java.util.Stack;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.IntNode;
-import com.fasterxml.jackson.databind.node.TextNode;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.node.IntNode;
+import tools.jackson.databind.node.StringNode;
 import com.google.auto.service.AutoService;
 
 import net.thisptr.jackson.jq.BuiltinFunction;
@@ -44,11 +43,9 @@ public class PathsFunction implements Function {
 				stack.pop();
 			}
 		} else if (in.isObject()) {
-			final Iterator<Entry<String, JsonNode>> iter = in.fields();
-			while (iter.hasNext()) {
-				final Entry<String, JsonNode> i = iter.next();
-				stack.push(new TextNode(i.getKey()));
-				applyRecursive(scope, i.getValue(), output, stack, predicate);
+			for (final Entry<String, JsonNode> entry : in.properties()) {
+				stack.push(new StringNode(entry.getKey()));
+				applyRecursive(scope, entry.getValue(), output, stack, predicate);
 				stack.pop();
 			}
 		}

--- a/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/functions/RIndexFunction.java
+++ b/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/functions/RIndexFunction.java
@@ -2,9 +2,9 @@ package net.thisptr.jackson.jq.internal.functions;
 
 import java.util.List;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.IntNode;
-import com.fasterxml.jackson.databind.node.NullNode;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.node.IntNode;
+import tools.jackson.databind.node.NullNode;
 import com.google.auto.service.AutoService;
 
 import net.thisptr.jackson.jq.BuiltinFunction;

--- a/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/functions/RangeFunction.java
+++ b/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/functions/RangeFunction.java
@@ -2,9 +2,9 @@ package net.thisptr.jackson.jq.internal.functions;
 
 import java.util.List;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.IntNode;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.node.IntNode;
 import com.google.auto.service.AutoService;
 
 import net.thisptr.jackson.jq.BuiltinFunction;

--- a/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/functions/ReverseFunction.java
+++ b/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/functions/ReverseFunction.java
@@ -2,8 +2,8 @@ package net.thisptr.jackson.jq.internal.functions;
 
 import java.util.List;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.ArrayNode;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.node.ArrayNode;
 import com.google.auto.service.AutoService;
 
 import net.thisptr.jackson.jq.BuiltinFunction;
@@ -36,8 +36,8 @@ public class ReverseFunction implements Function {
 
 		// below are to emulate jq behavior
 
-		if (in.isTextual()) {
-			if (in.asText().isEmpty()) {
+		if (in.isString()) {
+			if (in.asString().isEmpty()) {
 				output.emit(out, null);
 				return;
 			}

--- a/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/functions/SetPathFunction.java
+++ b/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/functions/SetPathFunction.java
@@ -2,7 +2,7 @@ package net.thisptr.jackson.jq.internal.functions;
 
 import java.util.List;
 
-import com.fasterxml.jackson.databind.JsonNode;
+import tools.jackson.databind.JsonNode;
 import com.google.auto.service.AutoService;
 
 import net.thisptr.jackson.jq.BuiltinFunction;

--- a/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/functions/SortByFunction.java
+++ b/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/functions/SortByFunction.java
@@ -3,9 +3,9 @@ package net.thisptr.jackson.jq.internal.functions;
 import java.util.ArrayList;
 import java.util.List;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.ArrayNode;
-import com.fasterxml.jackson.databind.node.JsonNodeType;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.node.ArrayNode;
+import tools.jackson.databind.node.JsonNodeType;
 import com.google.auto.service.AutoService;
 
 import net.thisptr.jackson.jq.BuiltinFunction;

--- a/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/functions/SplitFunction.java
+++ b/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/functions/SplitFunction.java
@@ -2,9 +2,9 @@ package net.thisptr.jackson.jq.internal.functions;
 
 import java.util.List;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.ArrayNode;
-import com.fasterxml.jackson.databind.node.TextNode;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.node.ArrayNode;
+import tools.jackson.databind.node.StringNode;
 import com.google.auto.service.AutoService;
 
 import net.thisptr.jackson.jq.BuiltinFunction;
@@ -25,12 +25,12 @@ public class SplitFunction implements Function {
 	@Override
 	public void apply(final Scope scope, final List<Expression> args, final JsonNode in, final Path ipath, final PathOutput output, final Version version) throws JsonQueryException {
 		args.get(0).apply(scope, in, (sep) -> {
-			if (!in.isTextual() || !sep.isTextual())
+			if (!in.isString() || !sep.isString())
 				throw new JsonQueryTypeException("split input and separator must be strings");
 
 			final ArrayNode row = scope.getObjectMapper().createArrayNode();
-			for (final String seg : Strings.split(in.asText(), sep.asText()))
-				row.add(new TextNode(seg));
+			for (final String seg : Strings.split(in.asString(), sep.asString()))
+				row.add(new StringNode(seg));
 
 			output.emit(row, null);
 		});

--- a/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/functions/ToDateIso8601Function.java
+++ b/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/functions/ToDateIso8601Function.java
@@ -1,8 +1,8 @@
 package net.thisptr.jackson.jq.internal.functions;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.JsonNodeType;
-import com.fasterxml.jackson.databind.node.TextNode;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.node.JsonNodeType;
+import tools.jackson.databind.node.StringNode;
 import com.google.auto.service.AutoService;
 import net.thisptr.jackson.jq.*;
 import net.thisptr.jackson.jq.exception.JsonQueryException;
@@ -22,7 +22,7 @@ public class ToDateIso8601Function implements Function  {
         try {
             long epochSeconds = in.asLong();
             String iso8601String = Instant.ofEpochSecond(epochSeconds).toString();
-            output.emit(new TextNode(iso8601String), null);
+            output.emit(new StringNode(iso8601String), null);
         } catch (DateTimeException e) {
             throw new JsonQueryException(e);
         }        

--- a/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/functions/ToEntriesFunction.java
+++ b/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/functions/ToEntriesFunction.java
@@ -4,11 +4,11 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map.Entry;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.ArrayNode;
-import com.fasterxml.jackson.databind.node.IntNode;
-import com.fasterxml.jackson.databind.node.ObjectNode;
-import com.fasterxml.jackson.databind.node.TextNode;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.node.ArrayNode;
+import tools.jackson.databind.node.IntNode;
+import tools.jackson.databind.node.ObjectNode;
+import tools.jackson.databind.node.StringNode;
 import com.google.auto.service.AutoService;
 
 import net.thisptr.jackson.jq.BuiltinFunction;
@@ -29,11 +29,9 @@ public class ToEntriesFunction implements Function {
 		final ArrayNode out = scope.getObjectMapper().createArrayNode();
 
 		if (in.isObject()) {
-			final Iterator<Entry<String, JsonNode>> iter = in.fields();
-			while (iter.hasNext()) {
-				final Entry<String, JsonNode> entry = iter.next();
+			for (final Entry<String, JsonNode> entry : in.properties()) {
 				final ObjectNode entryNode = scope.getObjectMapper().createObjectNode();
-				entryNode.set("key", new TextNode(entry.getKey()));
+				entryNode.set("key", new StringNode(entry.getKey()));
 				entryNode.set("value", entry.getValue());
 				out.add(entryNode);
 			}

--- a/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/functions/ToJsonFunction.java
+++ b/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/functions/ToJsonFunction.java
@@ -1,10 +1,10 @@
 package net.thisptr.jackson.jq.internal.functions;
 
-import java.io.IOException;
 import java.util.List;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.TextNode;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.node.StringNode;
 import com.google.auto.service.AutoService;
 
 import net.thisptr.jackson.jq.BuiltinFunction;
@@ -23,8 +23,8 @@ public class ToJsonFunction implements Function {
 	@Override
 	public void apply(final Scope scope, final List<Expression> args, final JsonNode in, final Path ipath, final PathOutput output, final Version version) throws JsonQueryException {
 		try {
-			output.emit(new TextNode(scope.getObjectMapper().writeValueAsString(in)), null);
-		} catch (final IOException e) {
+			output.emit(new StringNode(scope.getObjectMapper().writeValueAsString(in)), null);
+		} catch (final JacksonException e) {
 			throw new JsonQueryException(e);
 		}
 	}

--- a/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/functions/ToNumberFunction.java
+++ b/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/functions/ToNumberFunction.java
@@ -2,7 +2,7 @@ package net.thisptr.jackson.jq.internal.functions;
 
 import java.util.List;
 
-import com.fasterxml.jackson.databind.JsonNode;
+import tools.jackson.databind.JsonNode;
 import com.google.auto.service.AutoService;
 
 import net.thisptr.jackson.jq.BuiltinFunction;
@@ -23,9 +23,9 @@ public class ToNumberFunction implements Function {
 	public void apply(final Scope scope, final List<Expression> args, final JsonNode in, final Path ipath, final PathOutput output, final Version version) throws JsonQueryException {
 		if (in.isNumber()) {
 			output.emit(in, null);
-		} else if (in.isTextual()) {
+		} else if (in.isString()) {
 			try {
-				final double value = Double.parseDouble(in.asText());
+				final double value = Double.parseDouble(in.asString());
 				output.emit(JsonNodeUtils.asNumericNode(value), null);
 			} catch (final NumberFormatException e) {
 				throw new JsonQueryException(e);

--- a/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/functions/ToStringFunction.java
+++ b/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/functions/ToStringFunction.java
@@ -2,9 +2,9 @@ package net.thisptr.jackson.jq.internal.functions;
 
 import java.util.List;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.TextNode;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.node.StringNode;
 import com.google.auto.service.AutoService;
 
 import net.thisptr.jackson.jq.BuiltinFunction;
@@ -21,12 +21,12 @@ import net.thisptr.jackson.jq.path.Path;
 public class ToStringFunction implements Function {
 	@Override
 	public void apply(final Scope scope, final List<Expression> args, final JsonNode in, final Path ipath, final PathOutput output, final Version version) throws JsonQueryException {
-		if (in.isTextual()) {
+		if (in.isString()) {
 			output.emit(in, null);
 		} else {
 			try {
-				output.emit(new TextNode(scope.getObjectMapper().writeValueAsString(in)), null);
-			} catch (final JsonProcessingException e) {
+				output.emit(new StringNode(scope.getObjectMapper().writeValueAsString(in)), null);
+			} catch (final JacksonException e) {
 				throw new JsonQueryException(e);
 			}
 		}

--- a/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/functions/TypeFunction.java
+++ b/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/functions/TypeFunction.java
@@ -2,8 +2,8 @@ package net.thisptr.jackson.jq.internal.functions;
 
 import java.util.List;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.TextNode;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.node.StringNode;
 import com.google.auto.service.AutoService;
 
 import net.thisptr.jackson.jq.BuiltinFunction;
@@ -21,6 +21,6 @@ import net.thisptr.jackson.jq.path.Path;
 public class TypeFunction implements Function {
 	@Override
 	public void apply(final Scope scope, final List<Expression> args, final JsonNode in, final Path ipath, final PathOutput output, final Version version) throws JsonQueryException {
-		output.emit(new TextNode(JsonNodeUtils.typeOf(in)), null);
+		output.emit(new StringNode(JsonNodeUtils.typeOf(in)), null);
 	}
 }

--- a/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/functions/Utf8ByteLengthFunction.java
+++ b/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/functions/Utf8ByteLengthFunction.java
@@ -2,8 +2,8 @@ package net.thisptr.jackson.jq.internal.functions;
 
 import java.util.List;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.IntNode;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.node.IntNode;
 import com.google.auto.service.AutoService;
 
 import net.thisptr.jackson.jq.BuiltinFunction;
@@ -22,8 +22,8 @@ import net.thisptr.jackson.jq.path.Path;
 public class Utf8ByteLengthFunction implements Function {
 	@Override
 	public void apply(final Scope scope, final List<Expression> args, final JsonNode in, final Path ipath, final PathOutput output, final Version version) throws JsonQueryException {
-		if (!in.isTextual())
+		if (!in.isString())
 			throw new JsonQueryTypeException("%s only strings have UTF-8 byte length", in);
-		output.emit(IntNode.valueOf(UnicodeUtils.lengthUtf8(in.asText())), null);
+		output.emit(IntNode.valueOf(UnicodeUtils.lengthUtf8(in.asString())), null);
 	}
 }

--- a/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/functions/_MatchImplFunction.java
+++ b/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/functions/_MatchImplFunction.java
@@ -10,11 +10,12 @@ import org.joni.Region;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.ArrayNode;
-import com.fasterxml.jackson.databind.node.BooleanNode;
-import com.fasterxml.jackson.databind.node.JsonNodeType;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.node.ArrayNode;
+import tools.jackson.databind.node.BooleanNode;
+import tools.jackson.databind.node.JsonNodeType;
 import com.google.auto.service.AutoService;
 
 import net.thisptr.jackson.jq.BuiltinFunction;
@@ -35,7 +36,7 @@ public class _MatchImplFunction implements Function {
 	@Override
 	public void apply(final Scope scope, final List<Expression> args, final JsonNode in, final Path ipath, final PathOutput output, final Version version) throws JsonQueryException {
 		Preconditions.checkInputType("_match_impl/3", in, JsonNodeType.STRING);
-		final byte[] ibytes = in.asText().getBytes(StandardCharsets.UTF_8);
+		final byte[] ibytes = in.asString().getBytes(StandardCharsets.UTF_8);
 		final int[] cindex = UnicodeUtils.UTF8CharIndex(ibytes);
 
 		args.get(2).apply(scope, in, (test) -> {
@@ -44,7 +45,7 @@ public class _MatchImplFunction implements Function {
 				Preconditions.checkArgumentType("_match_impl/3", 2, flags, JsonNodeType.STRING, JsonNodeType.NULL);
 				args.get(0).apply(scope, in, (regex) -> {
 					Preconditions.checkArgumentType("_match_impl/3", 1, regex, JsonNodeType.STRING);
-					final OnigUtils.Pattern p = new OnigUtils.Pattern(regex.asText(), flags.isNull() ? null : flags.asText());
+					final OnigUtils.Pattern p = new OnigUtils.Pattern(regex.asString(), flags.isNull() ? null : flags.asString());
 					output.emit(match(scope.getObjectMapper(), p, ibytes, cindex, test.asBoolean()), null);
 				});
 			});
@@ -52,6 +53,7 @@ public class _MatchImplFunction implements Function {
 	}
 
 	@JsonIgnoreProperties(ignoreUnknown = true)
+	@JsonPropertyOrder({"offset", "length", "string", "name"})
 	private static class CaptureObject {
 		@JsonProperty("offset")
 		public int offset;
@@ -64,6 +66,7 @@ public class _MatchImplFunction implements Function {
 	}
 
 	@JsonIgnoreProperties(ignoreUnknown = true)
+	@JsonPropertyOrder({"offset", "length", "string", "captures"})
 	/* package private */static class MatchObject {
 		@JsonProperty("offset")
 		public int offset;

--- a/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/functions/_SubImplFunction.java
+++ b/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/functions/_SubImplFunction.java
@@ -9,12 +9,12 @@ import org.joni.Matcher;
 import org.joni.Option;
 import org.joni.Region;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.JsonNodeType;
-import com.fasterxml.jackson.databind.node.NullNode;
-import com.fasterxml.jackson.databind.node.ObjectNode;
-import com.fasterxml.jackson.databind.node.TextNode;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.node.JsonNodeType;
+import tools.jackson.databind.node.NullNode;
+import tools.jackson.databind.node.ObjectNode;
+import tools.jackson.databind.node.StringNode;
 import com.google.auto.service.AutoService;
 
 import net.thisptr.jackson.jq.BuiltinFunction;
@@ -41,8 +41,8 @@ public class _SubImplFunction implements Function {
 			args.get(2).apply(scope, in, (flagsText) -> {
 				Preconditions.checkArgumentType("_sub_impl/3", 3, flagsText, JsonNodeType.STRING);
 
-				final OnigUtils.Pattern p = new OnigUtils.Pattern(regexText.asText(), flagsText.asText());
-				final List<JsonNode> match = match(scope.getObjectMapper(), p, in.asText());
+				final OnigUtils.Pattern p = new OnigUtils.Pattern(regexText.asString(), flagsText.asString());
+				final List<JsonNode> match = match(scope.getObjectMapper(), p, in.asString());
 
 				// This just repeats same emit()s the number of times as the number of flags. This is to emulate jq behavior (which is probably a bug).
 				args.get(2).apply(scope, in, (dummy) -> {
@@ -58,20 +58,20 @@ public class _SubImplFunction implements Function {
 			for (int i = stack.size() - 1; i >= 0; --i) {
 				sb.append(stack.get(i));
 			}
-			output.emit(new TextNode(sb.toString()), null);
+			output.emit(new StringNode(sb.toString()), null);
 			return;
 		}
 
 		final JsonNode rhead = match.get(match.size() - 1);
 		final List<JsonNode> rtail = match.subList(0, match.size() - 1);
 
-		if (rhead.isTextual()) {
-			stack.push(rhead.textValue());
+		if (rhead.isString()) {
+			stack.push(rhead.stringValue());
 			replaceAndConcat(scope, stack, output, rtail, replaceExpr, in, flags);
 			stack.pop();
 		} else {
 			replaceExpr.apply(scope, rhead, (replacement) -> {
-				stack.push(replacement.asText());
+				stack.push(replacement.asString());
 				replaceAndConcat(scope, stack, output, rtail, replaceExpr, in, flags);
 				stack.pop();
 			});
@@ -88,7 +88,7 @@ public class _SubImplFunction implements Function {
 			if (m.search(offset, inputBytes.length, Option.NONE) < 0)
 				break;
 
-			result.add(TextNode.valueOf(new String(inputBytes, offset, m.getBegin() - offset, StandardCharsets.UTF_8)));
+			result.add(StringNode.valueOf(new String(inputBytes, offset, m.getBegin() - offset, StandardCharsets.UTF_8)));
 
 			final ObjectNode captures = mapper.createObjectNode();
 			final Region regions = m.getRegion();
@@ -99,7 +99,7 @@ public class _SubImplFunction implements Function {
 						continue;
 					if (regions.getBeg(i) >= 0) {
 						final String value = new String(inputBytes, regions.getBeg(i), regions.getEnd(i) - regions.getBeg(i), StandardCharsets.UTF_8);
-						captures.set(name, TextNode.valueOf(value));
+						captures.set(name, StringNode.valueOf(value));
 					} else {
 						captures.set(name, NullNode.getInstance());
 					}
@@ -111,7 +111,7 @@ public class _SubImplFunction implements Function {
 			offset = m.getEnd();
 		} while (pattern.global && offset != inputBytes.length);
 
-		result.add(TextNode.valueOf(new String(inputBytes, offset, inputBytes.length - offset, StandardCharsets.UTF_8)));
+		result.add(StringNode.valueOf(new String(inputBytes, offset, inputBytes.length - offset, StandardCharsets.UTF_8)));
 		return result;
 	}
 }

--- a/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/functions/debug/DebugScopeFunction.java
+++ b/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/functions/debug/DebugScopeFunction.java
@@ -4,8 +4,9 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
 import com.google.auto.service.AutoService;
 
 import net.thisptr.jackson.jq.BuiltinFunction;
@@ -21,8 +22,9 @@ import net.thisptr.jackson.jq.path.Path;
 @AutoService(Function.class)
 @BuiltinFunction("debug_scope/0")
 public class DebugScopeFunction implements Function {
-	private static final ObjectMapper MAPPER = new ObjectMapper()
-			.registerModule(JsonQueryJacksonModule.getInstance());
+	private static final ObjectMapper MAPPER = JsonMapper.builder()
+			.addModule(JsonQueryJacksonModule.getInstance())
+			.build();
 
 	@Override
 	public void apply(final Scope scope, final List<Expression> args, final JsonNode in, final Path ipath, final PathOutput output, final Version version) throws JsonQueryException {

--- a/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/functions/math/Atan2Function.java
+++ b/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/functions/math/Atan2Function.java
@@ -2,8 +2,8 @@ package net.thisptr.jackson.jq.internal.functions.math;
 
 import java.util.List;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.JsonNodeType;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.node.JsonNodeType;
 import com.google.auto.service.AutoService;
 
 import net.thisptr.jackson.jq.BuiltinFunction;

--- a/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/functions/math/PowFunction.java
+++ b/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/functions/math/PowFunction.java
@@ -2,8 +2,8 @@ package net.thisptr.jackson.jq.internal.functions.math;
 
 import java.util.List;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.JsonNodeType;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.node.JsonNodeType;
 import com.google.auto.service.AutoService;
 
 import net.thisptr.jackson.jq.BuiltinFunction;

--- a/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/misc/JsonNodeComparator.java
+++ b/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/misc/JsonNodeComparator.java
@@ -7,8 +7,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.JsonNodeType;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.node.JsonNodeType;
 
 @SuppressWarnings("serial")
 public class JsonNodeComparator implements Comparator<JsonNode>, Serializable {
@@ -70,8 +70,8 @@ public class JsonNodeComparator implements Comparator<JsonNode>, Serializable {
 	}
 
 	protected int compareObjectNode(final JsonNode o1, final JsonNode o2) {
-		final List<String> names1 = Lists.newArrayList(o1.fieldNames());
-		final List<String> names2 = Lists.newArrayList(o2.fieldNames());
+		final List<String> names1 = Lists.newArrayList(o1.propertyNames());
+		final List<String> names2 = Lists.newArrayList(o2.propertyNames());
 
 		// compare by keys
 		Collections.sort(names1);
@@ -120,7 +120,7 @@ public class JsonNodeComparator implements Comparator<JsonNode>, Serializable {
 		}
 
 		if (type == JsonNodeType.STRING || type == JsonNodeType.BINARY)
-			return o1.asText().compareTo(o2.asText());
+			return o1.asString().compareTo(o2.asString());
 
 		if (type == JsonNodeType.ARRAY) {
 			return compareArrayNode(o1, o2);

--- a/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/misc/JsonNodeUtils.java
+++ b/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/misc/JsonNodeUtils.java
@@ -5,15 +5,16 @@ import java.util.List;
 import java.util.Map.Entry;
 import java.util.function.Predicate;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.ArrayNode;
-import com.fasterxml.jackson.databind.node.DoubleNode;
-import com.fasterxml.jackson.databind.node.IntNode;
-import com.fasterxml.jackson.databind.node.LongNode;
-import com.fasterxml.jackson.databind.node.NullNode;
-import com.fasterxml.jackson.databind.node.ObjectNode;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
+import tools.jackson.databind.node.ArrayNode;
+import tools.jackson.databind.node.DoubleNode;
+import tools.jackson.databind.node.IntNode;
+import tools.jackson.databind.node.LongNode;
+import tools.jackson.databind.node.NullNode;
+import tools.jackson.databind.node.ObjectNode;
 
 public class JsonNodeUtils {
 	private JsonNodeUtils() {}
@@ -81,15 +82,14 @@ public class JsonNodeUtils {
 		return value;
 	}
 
-	private static final ObjectMapper MAPPER = new ObjectMapper()
-			.registerModule(JsonQueryJacksonModule.getInstance());
+	private static final ObjectMapper MAPPER = JsonMapper.builder()
+			.addModule(JsonQueryJacksonModule.getInstance())
+			.build();
 
 	private static JsonNode filterInternal(final JsonNode in, final Predicate<JsonNode> pred) {
 		if (in.isObject()) {
 			final ObjectNode out = MAPPER.createObjectNode();
-			final Iterator<Entry<String, JsonNode>> iter = in.fields();
-			while (iter.hasNext()) {
-				final Entry<String, JsonNode> entry = iter.next();
+			for (final Entry<String, JsonNode> entry : in.properties()) {
 				if (!pred.test(entry.getValue()))
 					continue;
 				out.set(entry.getKey(), filterInternal(entry.getValue(), pred));
@@ -119,7 +119,7 @@ public class JsonNodeUtils {
 	public static String toString(final JsonNode node) {
 		try {
 			return MAPPER.writeValueAsString(node);
-		} catch (final JsonProcessingException e) {
+		} catch (final JacksonException e) {
 			throw new RuntimeException(e);
 		}
 	}

--- a/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/misc/JsonQueryJacksonModule.java
+++ b/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/misc/JsonQueryJacksonModule.java
@@ -1,18 +1,17 @@
 package net.thisptr.jackson.jq.internal.misc;
 
-import java.io.IOException;
-import java.util.Iterator;
 import java.util.Map.Entry;
 
-import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.JsonSerializer;
-import com.fasterxml.jackson.databind.SerializerProvider;
-import com.fasterxml.jackson.databind.module.SimpleModule;
-import com.fasterxml.jackson.databind.node.ArrayNode;
-import com.fasterxml.jackson.databind.node.DoubleNode;
-import com.fasterxml.jackson.databind.node.FloatNode;
-import com.fasterxml.jackson.databind.node.ObjectNode;
+import tools.jackson.core.JsonGenerator;
+import tools.jackson.core.Version;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.SerializationContext;
+import tools.jackson.databind.ValueSerializer;
+import tools.jackson.databind.module.SimpleModule;
+import tools.jackson.databind.node.ArrayNode;
+import tools.jackson.databind.node.DoubleNode;
+import tools.jackson.databind.node.FloatNode;
+import tools.jackson.databind.node.ObjectNode;
 
 public class JsonQueryJacksonModule extends SimpleModule {
 	private static final long serialVersionUID = 1137650244815104623L;
@@ -24,7 +23,7 @@ public class JsonQueryJacksonModule extends SimpleModule {
 	}
 
 	private JsonQueryJacksonModule() {
-		super("JsonQuery", new com.fasterxml.jackson.core.Version(1, 0, 0, null, "net.thisptr", "jackson-jq"));
+		super("JsonQuery", new Version(1, 0, 0, null, "net.thisptr", "jackson-jq"));
 		addSerializer(DoubleNode.class, new DoubleNodeSerializer());
 		addSerializer(FloatNode.class, new FloatNodeSerializer());
 		addSerializer(ArrayNode.class, new ArrayNodeSerializer());
@@ -48,40 +47,38 @@ public class JsonQueryJacksonModule extends SimpleModule {
 		}
 	}
 
-	private static class ArrayNodeSerializer extends JsonSerializer<ArrayNode> {
+	private static class ArrayNodeSerializer extends ValueSerializer<ArrayNode> {
 		@Override
-		public void serialize(final ArrayNode value, final JsonGenerator gen, final SerializerProvider serializers) throws IOException {
+		public void serialize(final ArrayNode value, final JsonGenerator gen, final SerializationContext serializers) {
 			gen.writeStartArray();
 			for (final JsonNode element : value)
-				gen.writeObject(element);
+				gen.writePOJO(element);
 			gen.writeEndArray();
 		}
 	}
 
-	private static class ObjectNodeSerializer extends JsonSerializer<ObjectNode> {
+	private static class ObjectNodeSerializer extends ValueSerializer<ObjectNode> {
 
 		@Override
-		public void serialize(final ObjectNode value, final JsonGenerator gen, final SerializerProvider serializers) throws IOException {
+		public void serialize(final ObjectNode value, final JsonGenerator gen, final SerializationContext serializers) {
 			gen.writeStartObject();
-			final Iterator<Entry<String, JsonNode>> iter = value.fields();
-			while (iter.hasNext()) {
-				final Entry<String, JsonNode> entry = iter.next();
-				gen.writeObjectField(entry.getKey(), entry.getValue());
+			for (final Entry<String, JsonNode> entry : value.properties()) {
+				gen.writePOJOProperty(entry.getKey(), entry.getValue());
 			}
 			gen.writeEndObject();
 		}
 	}
 
-	private static class DoubleNodeSerializer extends JsonSerializer<DoubleNode> {
+	private static class DoubleNodeSerializer extends ValueSerializer<DoubleNode> {
 		@Override
-		public void serialize(DoubleNode value, JsonGenerator gen, SerializerProvider serializers) throws IOException {
+		public void serialize(DoubleNode value, JsonGenerator gen, SerializationContext serializers) {
 			gen.writeRawValue(format(value.asDouble()));
 		}
 	}
 
-	private static class FloatNodeSerializer extends JsonSerializer<FloatNode> {
+	private static class FloatNodeSerializer extends ValueSerializer<FloatNode> {
 		@Override
-		public void serialize(FloatNode value, JsonGenerator gen, SerializerProvider serializers) throws IOException {
+		public void serialize(FloatNode value, JsonGenerator gen, SerializationContext serializers) {
 			gen.writeRawValue(format(value.asDouble()));
 		}
 	}

--- a/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/misc/JsonQueryUtils.java
+++ b/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/misc/JsonQueryUtils.java
@@ -2,8 +2,8 @@ package net.thisptr.jackson.jq.internal.misc;
 
 import java.util.ArrayList;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.ArrayNode;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.node.ArrayNode;
 
 import net.thisptr.jackson.jq.Expression;
 import net.thisptr.jackson.jq.Scope;

--- a/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/misc/PathUtils.java
+++ b/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/misc/PathUtils.java
@@ -1,7 +1,7 @@
 package net.thisptr.jackson.jq.internal.misc;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.NullNode;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.node.NullNode;
 
 import net.thisptr.jackson.jq.exception.JsonQueryException;
 import net.thisptr.jackson.jq.path.ArrayIndexOfPath;
@@ -34,8 +34,8 @@ public class PathUtils {
 				path = new ArrayRangeIndexPath(path, start, end);
 			} else if (segObj.isNumber()) {
 				path = new ArrayIndexPath(path, segObj);
-			} else if (segObj.isTextual()) {
-				path = new ObjectFieldPath(path, segObj.asText());
+			} else if (segObj.isString()) {
+				path = new ObjectFieldPath(path, segObj.asString());
 			} else if (segObj.isArray()) {
 				path = new ArrayIndexOfPath(path, segObj);
 			} else {

--- a/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/misc/Preconditions.java
+++ b/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/misc/Preconditions.java
@@ -3,8 +3,8 @@ package net.thisptr.jackson.jq.internal.misc;
 import java.util.Arrays;
 import java.util.List;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.JsonNodeType;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.node.JsonNodeType;
 
 import net.thisptr.jackson.jq.Expression;
 import net.thisptr.jackson.jq.exception.IllegalJsonArgumentException;

--- a/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/misc/Range.java
+++ b/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/misc/Range.java
@@ -1,6 +1,6 @@
 package net.thisptr.jackson.jq.internal.misc;
 
-import com.fasterxml.jackson.databind.JsonNode;
+import tools.jackson.databind.JsonNode;
 
 public class Range {
 	public final long start;

--- a/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/misc/VersionRangeDeserializer.java
+++ b/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/misc/VersionRangeDeserializer.java
@@ -1,11 +1,8 @@
 package net.thisptr.jackson.jq.internal.misc;
 
-import java.io.IOException;
-
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.DeserializationContext;
-import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+import tools.jackson.core.JsonParser;
+import tools.jackson.databind.DeserializationContext;
+import tools.jackson.databind.deser.std.StdDeserializer;
 
 import net.thisptr.jackson.jq.VersionRange;
 
@@ -17,8 +14,8 @@ public class VersionRangeDeserializer extends StdDeserializer<VersionRange> {
 	}
 
 	@Override
-	public VersionRange deserialize(final JsonParser p, final DeserializationContext ctxt) throws IOException, JsonProcessingException {
-		final String text = p.readValueAs(String.class);
+	public VersionRange deserialize(final JsonParser p, final DeserializationContext ctxt) {
+		final String text = p.getString();
 		if (text == null)
 			return null;
 		return VersionRange.valueOf(text);

--- a/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/module/loaders/NullModuleLoader.java
+++ b/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/module/loaders/NullModuleLoader.java
@@ -1,6 +1,6 @@
 package net.thisptr.jackson.jq.internal.module.loaders;
 
-import com.fasterxml.jackson.databind.JsonNode;
+import tools.jackson.databind.JsonNode;
 
 import net.thisptr.jackson.jq.module.Module;
 import net.thisptr.jackson.jq.module.ModuleLoader;

--- a/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/operators/AlternativeOperator.java
+++ b/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/operators/AlternativeOperator.java
@@ -1,7 +1,7 @@
 package net.thisptr.jackson.jq.internal.operators;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
 
 import net.thisptr.jackson.jq.exception.JsonQueryException;
 import net.thisptr.jackson.jq.internal.misc.JsonNodeUtils;

--- a/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/operators/BinaryOperator.java
+++ b/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/operators/BinaryOperator.java
@@ -1,7 +1,7 @@
 package net.thisptr.jackson.jq.internal.operators;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
 
 import net.thisptr.jackson.jq.exception.JsonQueryException;
 

--- a/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/operators/ComparisonOperator.java
+++ b/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/operators/ComparisonOperator.java
@@ -1,8 +1,8 @@
 package net.thisptr.jackson.jq.internal.operators;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.BooleanNode;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.node.BooleanNode;
 
 import net.thisptr.jackson.jq.exception.JsonQueryException;
 import net.thisptr.jackson.jq.internal.misc.JsonNodeComparator;

--- a/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/operators/DivideOperator.java
+++ b/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/operators/DivideOperator.java
@@ -1,9 +1,9 @@
 package net.thisptr.jackson.jq.internal.operators;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.ArrayNode;
-import com.fasterxml.jackson.databind.node.TextNode;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.node.ArrayNode;
+import tools.jackson.databind.node.StringNode;
 
 import net.thisptr.jackson.jq.exception.JsonQueryException;
 import net.thisptr.jackson.jq.exception.JsonQueryTypeException;
@@ -20,10 +20,10 @@ public class DivideOperator implements BinaryOperator {
 			if (divisor == 0.0)
 				throw new JsonQueryException("%s and %s cannot be divided because the divisor is zero", lhs, rhs);
 			return JsonNodeUtils.asNumericNode(dividend / divisor);
-		} else if (lhs.isTextual() && rhs.isTextual()) {
+		} else if (lhs.isString() && rhs.isString()) {
 			final ArrayNode result = mapper.createArrayNode();
-			for (final String token : Strings.split(lhs.asText(), rhs.asText()))
-				result.add(new TextNode(token));
+			for (final String token : Strings.split(lhs.asString(), rhs.asString()))
+				result.add(new StringNode(token));
 			return result;
 		} else {
 			throw new JsonQueryTypeException("%s and %s cannot be divided", lhs, rhs);

--- a/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/operators/MinusOperator.java
+++ b/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/operators/MinusOperator.java
@@ -2,9 +2,9 @@ package net.thisptr.jackson.jq.internal.operators;
 
 import java.util.TreeSet;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.ArrayNode;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.node.ArrayNode;
 
 import net.thisptr.jackson.jq.exception.JsonQueryException;
 import net.thisptr.jackson.jq.exception.JsonQueryTypeException;

--- a/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/operators/ModuloOperator.java
+++ b/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/operators/ModuloOperator.java
@@ -1,7 +1,7 @@
 package net.thisptr.jackson.jq.internal.operators;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
 
 import net.thisptr.jackson.jq.exception.JsonQueryException;
 import net.thisptr.jackson.jq.exception.JsonQueryTypeException;
@@ -11,10 +11,14 @@ public class ModuloOperator implements BinaryOperator {
 	@Override
 	public JsonNode apply(ObjectMapper mapper, JsonNode lhs, JsonNode rhs) throws JsonQueryException {
 		if (lhs.isNumber() && rhs.isNumber()) {
-			final long divisor = rhs.asLong();
-			final long dividend = lhs.asLong();
-			if (Double.isNaN(rhs.asDouble()))
-				return JsonNodeUtils.asNumericNode(dividend);
+			// Check for NaN before calling asLong() as Jackson 3.x throws on NaN
+			final double rhsDouble = rhs.asDouble();
+			final double lhsDouble = lhs.asDouble();
+			if (Double.isNaN(rhsDouble)) {
+				return JsonNodeUtils.asNumericNode((long) lhsDouble);
+			}
+			final long divisor = (long) rhsDouble;
+			final long dividend = (long) lhsDouble;
 			if (divisor == 0L)
 				throw new JsonQueryException("%s and %s cannot be divided (remainder) because the divisor is zero", lhs, rhs);
 			return JsonNodeUtils.asNumericNode(dividend % divisor);

--- a/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/operators/MultiplyOperator.java
+++ b/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/operators/MultiplyOperator.java
@@ -1,13 +1,12 @@
 package net.thisptr.jackson.jq.internal.operators;
 
-import java.util.Iterator;
 import java.util.Map.Entry;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.NullNode;
-import com.fasterxml.jackson.databind.node.ObjectNode;
-import com.fasterxml.jackson.databind.node.TextNode;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.node.NullNode;
+import tools.jackson.databind.node.ObjectNode;
+import tools.jackson.databind.node.StringNode;
 
 import net.thisptr.jackson.jq.exception.JsonQueryException;
 import net.thisptr.jackson.jq.exception.JsonQueryTypeException;
@@ -23,20 +22,20 @@ public class MultiplyOperator implements BinaryOperator {
 		} else if (lhs.isNumber() && rhs.isNumber()) {
 			final double r = lhs.asDouble() * rhs.asDouble();
 			return JsonNodeUtils.asNumericNode(r);
-		} else if (lhs.isTextual() && rhs.isNumber()) {
+		} else if (lhs.isString() && rhs.isNumber()) {
 			final double count = rhs.asDouble();
 			if (count <= 0)
 				return NullNode.getInstance();
 			if (count < 2)
 				return lhs;
-			return new TextNode(Strings.repeat(lhs.asText(), (int) count));
-		} else if (lhs.isNumber() && rhs.isTextual()) {
+			return new StringNode(Strings.repeat(lhs.asString(), (int) count));
+		} else if (lhs.isNumber() && rhs.isString()) {
 			final double count = lhs.asDouble();
 			if (count <= 0)
 				return NullNode.getInstance();
 			if (count < 2)
 				return rhs;
-			return new TextNode(Strings.repeat(rhs.asText(), (int) count));
+			return new StringNode(Strings.repeat(rhs.asString(), (int) count));
 		} else if (lhs.isObject() && rhs.isObject()) {
 			return mergeRecursive(mapper, (ObjectNode) lhs, (ObjectNode) rhs);
 		} else {
@@ -47,15 +46,11 @@ public class MultiplyOperator implements BinaryOperator {
 	private static ObjectNode mergeRecursive(final ObjectMapper mapper, final ObjectNode lhs, final ObjectNode rhs) {
 		final ObjectNode result = mapper.createObjectNode();
 
-		final Iterator<Entry<String, JsonNode>> liter = lhs.fields();
-		while (liter.hasNext()) {
-			final Entry<String, JsonNode> e = liter.next();
+		for (final Entry<String, JsonNode> e : lhs.properties()) {
 			result.set(e.getKey(), e.getValue());
 		}
 
-		final Iterator<Entry<String, JsonNode>> riter = rhs.fields();
-		while (riter.hasNext()) {
-			final Entry<String, JsonNode> e = riter.next();
+		for (final Entry<String, JsonNode> e : rhs.properties()) {
 			final JsonNode l = result.get(e.getKey());
 			final JsonNode r = e.getValue();
 

--- a/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/operators/PlusOperator.java
+++ b/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/operators/PlusOperator.java
@@ -1,13 +1,12 @@
 package net.thisptr.jackson.jq.internal.operators;
 
-import java.util.Iterator;
 import java.util.Map.Entry;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.ArrayNode;
-import com.fasterxml.jackson.databind.node.ObjectNode;
-import com.fasterxml.jackson.databind.node.TextNode;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.node.ArrayNode;
+import tools.jackson.databind.node.ObjectNode;
+import tools.jackson.databind.node.StringNode;
 
 import net.thisptr.jackson.jq.exception.JsonQueryException;
 import net.thisptr.jackson.jq.exception.JsonQueryTypeException;
@@ -27,18 +26,14 @@ public class PlusOperator implements BinaryOperator {
 			result.addAll((ArrayNode) lhs);
 			result.addAll((ArrayNode) rhs);
 			return result;
-		} else if (lhs.isTextual() && rhs.isTextual()) {
-			return new TextNode(lhs.asText() + rhs.asText());
+		} else if (lhs.isString() && rhs.isString()) {
+			return new StringNode(lhs.asString() + rhs.asString());
 		} else if (lhs.isObject() && rhs.isObject()) {
 			final ObjectNode result = mapper.createObjectNode();
-			final Iterator<Entry<String, JsonNode>> liter = lhs.fields();
-			while (liter.hasNext()) {
-				final Entry<String, JsonNode> e = liter.next();
+			for (final Entry<String, JsonNode> e : lhs.properties()) {
 				result.set(e.getKey(), e.getValue());
 			}
-			final Iterator<Entry<String, JsonNode>> riter = rhs.fields();
-			while (riter.hasNext()) {
-				final Entry<String, JsonNode> e = riter.next();
+			for (final Entry<String, JsonNode> e : rhs.properties()) {
 				result.set(e.getKey(), e.getValue());
 			}
 			return result;

--- a/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/tree/ArrayConstruction.java
+++ b/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/tree/ArrayConstruction.java
@@ -1,7 +1,7 @@
 package net.thisptr.jackson.jq.internal.tree;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.ArrayNode;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.node.ArrayNode;
 
 import net.thisptr.jackson.jq.Expression;
 import net.thisptr.jackson.jq.PathOutput;

--- a/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/tree/BreakExpression.java
+++ b/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/tree/BreakExpression.java
@@ -1,6 +1,6 @@
 package net.thisptr.jackson.jq.internal.tree;
 
-import com.fasterxml.jackson.databind.JsonNode;
+import tools.jackson.databind.JsonNode;
 
 import net.thisptr.jackson.jq.Expression;
 import net.thisptr.jackson.jq.PathOutput;

--- a/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/tree/Conditional.java
+++ b/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/tree/Conditional.java
@@ -2,7 +2,7 @@ package net.thisptr.jackson.jq.internal.tree;
 
 import java.util.List;
 
-import com.fasterxml.jackson.databind.JsonNode;
+import tools.jackson.databind.JsonNode;
 
 import net.thisptr.jackson.jq.Expression;
 import net.thisptr.jackson.jq.PathOutput;

--- a/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/tree/FieldConstruction.java
+++ b/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/tree/FieldConstruction.java
@@ -1,6 +1,6 @@
 package net.thisptr.jackson.jq.internal.tree;
 
-import com.fasterxml.jackson.databind.JsonNode;
+import tools.jackson.databind.JsonNode;
 
 import net.thisptr.jackson.jq.Scope;
 import net.thisptr.jackson.jq.exception.JsonQueryException;

--- a/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/tree/ForeachExpression.java
+++ b/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/tree/ForeachExpression.java
@@ -3,7 +3,7 @@ package net.thisptr.jackson.jq.internal.tree;
 import java.util.List;
 import java.util.Stack;
 
-import com.fasterxml.jackson.databind.JsonNode;
+import tools.jackson.databind.JsonNode;
 
 import net.thisptr.jackson.jq.Expression;
 import net.thisptr.jackson.jq.PathOutput;

--- a/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/tree/FormattingFilter.java
+++ b/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/tree/FormattingFilter.java
@@ -2,7 +2,7 @@ package net.thisptr.jackson.jq.internal.tree;
 
 import java.util.Collections;
 
-import com.fasterxml.jackson.databind.JsonNode;
+import tools.jackson.databind.JsonNode;
 
 import net.thisptr.jackson.jq.Expression;
 import net.thisptr.jackson.jq.Function;

--- a/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/tree/FunctionCall.java
+++ b/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/tree/FunctionCall.java
@@ -2,7 +2,7 @@ package net.thisptr.jackson.jq.internal.tree;
 
 import java.util.List;
 
-import com.fasterxml.jackson.databind.JsonNode;
+import tools.jackson.databind.JsonNode;
 
 import net.thisptr.jackson.jq.Expression;
 import net.thisptr.jackson.jq.Function;

--- a/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/tree/FunctionDefinition.java
+++ b/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/tree/FunctionDefinition.java
@@ -2,7 +2,7 @@ package net.thisptr.jackson.jq.internal.tree;
 
 import java.util.List;
 
-import com.fasterxml.jackson.databind.JsonNode;
+import tools.jackson.databind.JsonNode;
 
 import net.thisptr.jackson.jq.Expression;
 import net.thisptr.jackson.jq.PathOutput;

--- a/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/tree/IdentifierKeyFieldConstruction.java
+++ b/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/tree/IdentifierKeyFieldConstruction.java
@@ -1,6 +1,6 @@
 package net.thisptr.jackson.jq.internal.tree;
 
-import com.fasterxml.jackson.databind.JsonNode;
+import tools.jackson.databind.JsonNode;
 
 import net.thisptr.jackson.jq.Expression;
 import net.thisptr.jackson.jq.Scope;

--- a/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/tree/ImportStatement.java
+++ b/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/tree/ImportStatement.java
@@ -1,7 +1,7 @@
 package net.thisptr.jackson.jq.internal.tree;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.TextNode;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.node.StringNode;
 
 import net.thisptr.jackson.jq.Expression;
 import net.thisptr.jackson.jq.internal.utils.ExpressionUtils;
@@ -32,7 +32,7 @@ public class ImportStatement {
 	public String toString() {
 		final StringBuilder s = new StringBuilder();
 		s.append("import ");
-		s.append(new TextNode(path).toString());
+		s.append(new StringNode(path).toString());
 		s.append(" as ");
 		if (dollarImport)
 			s.append('$');

--- a/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/tree/JsonQueryKeyFieldConstruction.java
+++ b/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/tree/JsonQueryKeyFieldConstruction.java
@@ -1,6 +1,6 @@
 package net.thisptr.jackson.jq.internal.tree;
 
-import com.fasterxml.jackson.databind.JsonNode;
+import tools.jackson.databind.JsonNode;
 
 import net.thisptr.jackson.jq.Expression;
 import net.thisptr.jackson.jq.Scope;
@@ -19,9 +19,9 @@ public class JsonQueryKeyFieldConstruction implements FieldConstruction {
 	@Override
 	public void evaluate(final Scope scope, final JsonNode in, final FieldConsumer consumer) throws JsonQueryException {
 		key.apply(scope, in, (k) -> {
-			if (!k.isTextual())
+			if (!k.isString())
 				throw new JsonQueryTypeException("Cannot use %s as object key", k);
-			value.apply(scope, in, (v) -> consumer.accept(k.asText(), v));
+			value.apply(scope, in, (v) -> consumer.accept(k.asString(), v));
 		});
 	}
 

--- a/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/tree/ModuleDirective.java
+++ b/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/tree/ModuleDirective.java
@@ -1,6 +1,6 @@
 package net.thisptr.jackson.jq.internal.tree;
 
-import com.fasterxml.jackson.databind.JsonNode;
+import tools.jackson.databind.JsonNode;
 
 import net.thisptr.jackson.jq.Expression;
 import net.thisptr.jackson.jq.internal.utils.ExpressionUtils;

--- a/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/tree/NegativeExpression.java
+++ b/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/tree/NegativeExpression.java
@@ -1,6 +1,6 @@
 package net.thisptr.jackson.jq.internal.tree;
 
-import com.fasterxml.jackson.databind.JsonNode;
+import tools.jackson.databind.JsonNode;
 
 import net.thisptr.jackson.jq.Expression;
 import net.thisptr.jackson.jq.PathOutput;

--- a/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/tree/ObjectConstruction.java
+++ b/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/tree/ObjectConstruction.java
@@ -6,8 +6,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.ObjectNode;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.node.ObjectNode;
 
 import net.thisptr.jackson.jq.Expression;
 import net.thisptr.jackson.jq.PathOutput;

--- a/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/tree/PipedQuery.java
+++ b/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/tree/PipedQuery.java
@@ -3,7 +3,7 @@ package net.thisptr.jackson.jq.internal.tree;
 import java.util.List;
 import java.util.Stack;
 
-import com.fasterxml.jackson.databind.JsonNode;
+import tools.jackson.databind.JsonNode;
 
 import net.thisptr.jackson.jq.Expression;
 import net.thisptr.jackson.jq.PathOutput;

--- a/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/tree/RecursionOperator.java
+++ b/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/tree/RecursionOperator.java
@@ -1,9 +1,8 @@
 package net.thisptr.jackson.jq.internal.tree;
 
-import java.util.Iterator;
 import java.util.Map.Entry;
 
-import com.fasterxml.jackson.databind.JsonNode;
+import tools.jackson.databind.JsonNode;
 
 import net.thisptr.jackson.jq.Expression;
 import net.thisptr.jackson.jq.PathOutput;
@@ -17,9 +16,7 @@ public class RecursionOperator implements Expression {
 	private static void pathRecursive(final Scope scope, final JsonNode in, final Path path, final PathOutput output) throws JsonQueryException {
 		output.emit(in, path);
 		if (in.isObject()) {
-			final Iterator<Entry<String, JsonNode>> iter = in.fields();
-			while (iter.hasNext()) {
-				final Entry<String, JsonNode> entry = iter.next();
+			for (final Entry<String, JsonNode> entry : in.properties()) {
 				pathRecursive(scope, entry.getValue(), ObjectFieldPath.chainIfNotNull(path, entry.getKey()), output);
 			}
 		} else if (in.isArray()) {

--- a/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/tree/ReduceExpression.java
+++ b/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/tree/ReduceExpression.java
@@ -4,8 +4,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Stack;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.NullNode;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.node.NullNode;
 
 import net.thisptr.jackson.jq.Expression;
 import net.thisptr.jackson.jq.PathOutput;

--- a/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/tree/SemicolonOperator.java
+++ b/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/tree/SemicolonOperator.java
@@ -2,7 +2,7 @@ package net.thisptr.jackson.jq.internal.tree;
 
 import java.util.List;
 
-import com.fasterxml.jackson.databind.JsonNode;
+import tools.jackson.databind.JsonNode;
 
 import net.thisptr.jackson.jq.Expression;
 import net.thisptr.jackson.jq.PathOutput;

--- a/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/tree/StringInterpolation.java
+++ b/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/tree/StringInterpolation.java
@@ -3,8 +3,8 @@ package net.thisptr.jackson.jq.internal.tree;
 import java.util.List;
 import java.util.Stack;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.TextNode;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.node.StringNode;
 
 import net.thisptr.jackson.jq.Expression;
 import net.thisptr.jackson.jq.PathOutput;
@@ -30,6 +30,16 @@ public class StringInterpolation implements Expression {
 		recurse(scope, in, output, stack, interpolations);
 	}
 
+	private static String nodeToString(final JsonNode node) {
+		if (node.isNull()) {
+			return "null";
+		} else if (node.isValueNode()) {
+			return node.asString();
+		} else {
+			return node.toString();
+		}
+	}
+
 	private void recurse(final Scope scope, final JsonNode in, final PathOutput output, final Stack<Pair<Integer, JsonNode>> stack, final List<Pair<Integer, Expression>> interpolations) throws JsonQueryException {
 		if (interpolations.isEmpty()) {
 			final StringBuilder builder = new StringBuilder();
@@ -39,10 +49,10 @@ public class StringInterpolation implements Expression {
 				builder.append(template.substring(pos, head._1));
 				pos = head._1;
 
-				builder.append(head._2.isValueNode() ? head._2.asText() : head._2.toString());
+				builder.append(nodeToString(head._2));
 			}
 			builder.append(template.substring(pos));
-			output.emit(new TextNode(builder.toString()), null);
+			output.emit(new StringNode(builder.toString()), null);
 		} else {
 			final Pair<Integer, Expression> rhead = interpolations.get(interpolations.size() - 1);
 			final List<Pair<Integer, Expression>> rtail = interpolations.subList(0, interpolations.size() - 1);

--- a/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/tree/StringKeyFieldConstruction.java
+++ b/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/tree/StringKeyFieldConstruction.java
@@ -1,6 +1,6 @@
 package net.thisptr.jackson.jq.internal.tree;
 
-import com.fasterxml.jackson.databind.JsonNode;
+import tools.jackson.databind.JsonNode;
 
 import net.thisptr.jackson.jq.Expression;
 import net.thisptr.jackson.jq.Scope;
@@ -23,12 +23,12 @@ public class StringKeyFieldConstruction implements FieldConstruction {
 	@Override
 	public void evaluate(final Scope scope, final JsonNode in, final FieldConsumer consumer) throws JsonQueryException {
 		key.apply(scope, in, (k) -> {
-			if (!k.isTextual())
+			if (!k.isString())
 				throw new JsonQueryException("key must evaluate to string");
 			if (value == null) {
-				consumer.accept(k.asText(), JsonNodeUtils.nullToNullNode(in.get(k.asText())));
+				consumer.accept(k.asString(), JsonNodeUtils.nullToNullNode(in.get(k.asString())));
 			} else {
-				value.apply(scope, in, (v) -> consumer.accept(k.asText(), v));
+				value.apply(scope, in, (v) -> consumer.accept(k.asString(), v));
 			}
 		});
 	}

--- a/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/tree/ThisObject.java
+++ b/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/tree/ThisObject.java
@@ -1,6 +1,6 @@
 package net.thisptr.jackson.jq.internal.tree;
 
-import com.fasterxml.jackson.databind.JsonNode;
+import tools.jackson.databind.JsonNode;
 
 import net.thisptr.jackson.jq.Expression;
 import net.thisptr.jackson.jq.PathOutput;

--- a/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/tree/TopLevelExpression.java
+++ b/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/tree/TopLevelExpression.java
@@ -2,7 +2,7 @@ package net.thisptr.jackson.jq.internal.tree;
 
 import java.util.List;
 
-import com.fasterxml.jackson.databind.JsonNode;
+import tools.jackson.databind.JsonNode;
 
 import net.thisptr.jackson.jq.Expression;
 import net.thisptr.jackson.jq.PathOutput;

--- a/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/tree/TryCatch.java
+++ b/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/tree/TryCatch.java
@@ -1,6 +1,6 @@
 package net.thisptr.jackson.jq.internal.tree;
 
-import com.fasterxml.jackson.databind.JsonNode;
+import tools.jackson.databind.JsonNode;
 
 import net.thisptr.jackson.jq.Expression;
 import net.thisptr.jackson.jq.PathOutput;

--- a/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/tree/Tuple.java
+++ b/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/tree/Tuple.java
@@ -2,7 +2,7 @@ package net.thisptr.jackson.jq.internal.tree;
 
 import java.util.List;
 
-import com.fasterxml.jackson.databind.JsonNode;
+import tools.jackson.databind.JsonNode;
 
 import net.thisptr.jackson.jq.Expression;
 import net.thisptr.jackson.jq.PathOutput;

--- a/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/tree/VariableAccess.java
+++ b/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/tree/VariableAccess.java
@@ -1,6 +1,6 @@
 package net.thisptr.jackson.jq.internal.tree;
 
-import com.fasterxml.jackson.databind.JsonNode;
+import tools.jackson.databind.JsonNode;
 
 import net.thisptr.jackson.jq.Expression;
 import net.thisptr.jackson.jq.PathOutput;

--- a/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/tree/VariableKeyFieldConstruction.java
+++ b/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/tree/VariableKeyFieldConstruction.java
@@ -1,6 +1,6 @@
 package net.thisptr.jackson.jq.internal.tree;
 
-import com.fasterxml.jackson.databind.JsonNode;
+import tools.jackson.databind.JsonNode;
 
 import net.thisptr.jackson.jq.Scope;
 import net.thisptr.jackson.jq.exception.JsonQueryException;

--- a/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/tree/binaryop/AlternativeOperatorExpression.java
+++ b/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/tree/binaryop/AlternativeOperatorExpression.java
@@ -2,7 +2,7 @@ package net.thisptr.jackson.jq.internal.tree.binaryop;
 
 import java.util.concurrent.atomic.AtomicBoolean;
 
-import com.fasterxml.jackson.databind.JsonNode;
+import tools.jackson.databind.JsonNode;
 
 import net.thisptr.jackson.jq.Expression;
 import net.thisptr.jackson.jq.PathOutput;

--- a/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/tree/binaryop/BooleanAndExpression.java
+++ b/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/tree/binaryop/BooleanAndExpression.java
@@ -1,7 +1,7 @@
 package net.thisptr.jackson.jq.internal.tree.binaryop;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.BooleanNode;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.node.BooleanNode;
 
 import net.thisptr.jackson.jq.Expression;
 import net.thisptr.jackson.jq.PathOutput;

--- a/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/tree/binaryop/BooleanOrExpression.java
+++ b/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/tree/binaryop/BooleanOrExpression.java
@@ -1,7 +1,7 @@
 package net.thisptr.jackson.jq.internal.tree.binaryop;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.BooleanNode;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.node.BooleanNode;
 
 import net.thisptr.jackson.jq.Expression;
 import net.thisptr.jackson.jq.PathOutput;

--- a/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/tree/binaryop/SimpleBinaryOperatorExpression.java
+++ b/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/tree/binaryop/SimpleBinaryOperatorExpression.java
@@ -1,6 +1,6 @@
 package net.thisptr.jackson.jq.internal.tree.binaryop;
 
-import com.fasterxml.jackson.databind.JsonNode;
+import tools.jackson.databind.JsonNode;
 
 import net.thisptr.jackson.jq.Expression;
 import net.thisptr.jackson.jq.PathOutput;

--- a/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/tree/binaryop/assignment/Assignment.java
+++ b/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/tree/binaryop/assignment/Assignment.java
@@ -3,7 +3,7 @@ package net.thisptr.jackson.jq.internal.tree.binaryop.assignment;
 import java.util.ArrayList;
 import java.util.List;
 
-import com.fasterxml.jackson.databind.JsonNode;
+import tools.jackson.databind.JsonNode;
 
 import net.thisptr.jackson.jq.Expression;
 import net.thisptr.jackson.jq.PathOutput;

--- a/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/tree/binaryop/assignment/ComplexAssignment.java
+++ b/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/tree/binaryop/assignment/ComplexAssignment.java
@@ -3,8 +3,8 @@ package net.thisptr.jackson.jq.internal.tree.binaryop.assignment;
 import java.util.ArrayList;
 import java.util.List;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.NullNode;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.node.NullNode;
 
 import net.thisptr.jackson.jq.Expression;
 import net.thisptr.jackson.jq.PathOutput;

--- a/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/tree/binaryop/assignment/UpdateAssignment.java
+++ b/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/tree/binaryop/assignment/UpdateAssignment.java
@@ -3,8 +3,8 @@ package net.thisptr.jackson.jq.internal.tree.binaryop.assignment;
 import java.util.ArrayList;
 import java.util.List;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.NullNode;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.node.NullNode;
 
 import net.thisptr.jackson.jq.Expression;
 import net.thisptr.jackson.jq.PathOutput;

--- a/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/tree/fieldaccess/BracketExtractFieldAccess.java
+++ b/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/tree/fieldaccess/BracketExtractFieldAccess.java
@@ -1,6 +1,6 @@
 package net.thisptr.jackson.jq.internal.tree.fieldaccess;
 
-import com.fasterxml.jackson.databind.JsonNode;
+import tools.jackson.databind.JsonNode;
 
 import net.thisptr.jackson.jq.Expression;
 import net.thisptr.jackson.jq.PathOutput;

--- a/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/tree/fieldaccess/BracketFieldAccess.java
+++ b/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/tree/fieldaccess/BracketFieldAccess.java
@@ -1,6 +1,6 @@
 package net.thisptr.jackson.jq.internal.tree.fieldaccess;
 
-import com.fasterxml.jackson.databind.JsonNode;
+import tools.jackson.databind.JsonNode;
 
 import net.thisptr.jackson.jq.Expression;
 import net.thisptr.jackson.jq.PathOutput;
@@ -57,8 +57,8 @@ public class BracketFieldAccess extends FieldAccess {
 				target.apply(scope, in, path, (pobj, ppath) -> {
 					if (accessor.isNumber()) {
 						emitArrayIndexPath(permissive, accessor, pobj, ppath, output, requirePath);
-					} else if (accessor.isTextual()) {
-						emitObjectFieldPath(permissive, accessor.asText(), pobj, ppath, output, requirePath);
+					} else if (accessor.isString()) {
+						emitObjectFieldPath(permissive, accessor.asString(), pobj, ppath, output, requirePath);
 					} else if (accessor.isArray()) {
 						emitArrayIndexOfPath(permissive, accessor, pobj, ppath, output, requirePath);
 					} else {

--- a/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/tree/fieldaccess/FieldAccess.java
+++ b/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/tree/fieldaccess/FieldAccess.java
@@ -1,12 +1,11 @@
 package net.thisptr.jackson.jq.internal.tree.fieldaccess;
 
-import java.util.Iterator;
 import java.util.Map.Entry;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.ObjectNode;
-import com.fasterxml.jackson.databind.node.TextNode;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.node.ObjectNode;
+import tools.jackson.databind.node.StringNode;
 
 import net.thisptr.jackson.jq.Expression;
 import net.thisptr.jackson.jq.PathOutput;
@@ -39,9 +38,7 @@ public abstract class FieldAccess implements Expression {
 			for (int i = 0; i < pobj.size(); ++i)
 				output.emit(pobj.get(i), ArrayIndexPath.chainIfNotNull(ppath, i));
 		} else if (pobj.isObject()) {
-			final Iterator<Entry<String, JsonNode>> iter = pobj.fields();
-			while (iter.hasNext()) {
-				final Entry<String, JsonNode> entry = iter.next();
+			for (final Entry<String, JsonNode> entry : pobj.properties()) {
 				output.emit(entry.getValue(), ObjectFieldPath.chainIfNotNull(ppath, entry.getKey()));
 			}
 		} else {
@@ -52,7 +49,7 @@ public abstract class FieldAccess implements Expression {
 
 	protected static void emitObjectFieldPath(boolean permissive, String key, final JsonNode pobj, final Path ppath, final PathOutput output, final boolean requirePath) throws JsonQueryException {
 		if (requirePath && ppath == null)
-			throw new JsonQueryException("Invalid path expression near attempt to access element %s of %s", JsonNodeUtils.toString(TextNode.valueOf(key)), JsonNodeUtils.toString(pobj));
+			throw new JsonQueryException("Invalid path expression near attempt to access element %s of %s", JsonNodeUtils.toString(StringNode.valueOf(key)), JsonNodeUtils.toString(pobj));
 		ObjectFieldPath.resolve(pobj, ppath, output, key, permissive);
 	}
 

--- a/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/tree/fieldaccess/IdentifierFieldAccess.java
+++ b/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/tree/fieldaccess/IdentifierFieldAccess.java
@@ -1,6 +1,6 @@
 package net.thisptr.jackson.jq.internal.tree.fieldaccess;
 
-import com.fasterxml.jackson.databind.JsonNode;
+import tools.jackson.databind.JsonNode;
 
 import net.thisptr.jackson.jq.Expression;
 import net.thisptr.jackson.jq.PathOutput;

--- a/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/tree/fieldaccess/StringFieldAccess.java
+++ b/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/tree/fieldaccess/StringFieldAccess.java
@@ -1,6 +1,6 @@
 package net.thisptr.jackson.jq.internal.tree.fieldaccess;
 
-import com.fasterxml.jackson.databind.JsonNode;
+import tools.jackson.databind.JsonNode;
 
 import net.thisptr.jackson.jq.Expression;
 import net.thisptr.jackson.jq.PathOutput;
@@ -33,9 +33,9 @@ public class StringFieldAccess extends FieldAccess {
 	public void apply(final Scope scope, final JsonNode in, final Path path, final PathOutput output, final boolean requirePath) throws JsonQueryException {
 		field.apply(scope, in, (key) -> {
 			target.apply(scope, in, path, (pobj, ppath) -> {
-				if (!key.isTextual() && !permissive)
+				if (!key.isString() && !permissive)
 					throw new IllegalStateException(); // FIXME: exception type
-				emitObjectFieldPath(permissive, key.asText(), pobj, ppath, output, requirePath);
+				emitObjectFieldPath(permissive, key.asString(), pobj, ppath, output, requirePath);
 			}, requirePath);
 		});
 	}

--- a/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/tree/literal/BooleanLiteral.java
+++ b/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/tree/literal/BooleanLiteral.java
@@ -1,6 +1,6 @@
 package net.thisptr.jackson.jq.internal.tree.literal;
 
-import com.fasterxml.jackson.databind.node.BooleanNode;
+import tools.jackson.databind.node.BooleanNode;
 
 public class BooleanLiteral extends ValueLiteral {
 	public BooleanLiteral(final boolean value) {

--- a/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/tree/literal/DoubleLiteral.java
+++ b/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/tree/literal/DoubleLiteral.java
@@ -1,6 +1,6 @@
 package net.thisptr.jackson.jq.internal.tree.literal;
 
-import com.fasterxml.jackson.databind.node.DoubleNode;
+import tools.jackson.databind.node.DoubleNode;
 
 public class DoubleLiteral extends ValueLiteral {
 	public DoubleLiteral(final double value) {

--- a/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/tree/literal/NullLiteral.java
+++ b/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/tree/literal/NullLiteral.java
@@ -1,6 +1,6 @@
 package net.thisptr.jackson.jq.internal.tree.literal;
 
-import com.fasterxml.jackson.databind.node.NullNode;
+import tools.jackson.databind.node.NullNode;
 
 public class NullLiteral extends ValueLiteral {
 	public NullLiteral() {

--- a/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/tree/literal/StringLiteral.java
+++ b/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/tree/literal/StringLiteral.java
@@ -1,9 +1,9 @@
 package net.thisptr.jackson.jq.internal.tree.literal;
 
-import com.fasterxml.jackson.databind.node.TextNode;
+import tools.jackson.databind.node.StringNode;
 
 public class StringLiteral extends ValueLiteral {
 	public StringLiteral(final String text) {
-		super(new TextNode(text));
+		super(new StringNode(text));
 	}
 }

--- a/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/tree/literal/ValueLiteral.java
+++ b/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/tree/literal/ValueLiteral.java
@@ -1,6 +1,6 @@
 package net.thisptr.jackson.jq.internal.tree.literal;
 
-import com.fasterxml.jackson.databind.JsonNode;
+import tools.jackson.databind.JsonNode;
 
 import net.thisptr.jackson.jq.Expression;
 import net.thisptr.jackson.jq.PathOutput;

--- a/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/tree/matcher/PatternMatcher.java
+++ b/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/tree/matcher/PatternMatcher.java
@@ -3,7 +3,7 @@ package net.thisptr.jackson.jq.internal.tree.matcher;
 import java.util.List;
 import java.util.Stack;
 
-import com.fasterxml.jackson.databind.JsonNode;
+import tools.jackson.databind.JsonNode;
 
 import net.thisptr.jackson.jq.Scope;
 import net.thisptr.jackson.jq.exception.JsonQueryException;

--- a/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/tree/matcher/matchers/ArrayMatcher.java
+++ b/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/tree/matcher/matchers/ArrayMatcher.java
@@ -3,8 +3,8 @@ package net.thisptr.jackson.jq.internal.tree.matcher.matchers;
 import java.util.List;
 import java.util.Stack;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.NullNode;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.node.NullNode;
 
 import net.thisptr.jackson.jq.Scope;
 import net.thisptr.jackson.jq.exception.JsonQueryException;

--- a/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/tree/matcher/matchers/ObjectMatcher.java
+++ b/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/tree/matcher/matchers/ObjectMatcher.java
@@ -3,8 +3,8 @@ package net.thisptr.jackson.jq.internal.tree.matcher.matchers;
 import java.util.List;
 import java.util.Stack;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.NullNode;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.node.NullNode;
 
 import net.thisptr.jackson.jq.Expression;
 import net.thisptr.jackson.jq.Scope;
@@ -49,7 +49,7 @@ public class ObjectMatcher implements PatternMatcher {
 			final StringBuilder sb = new StringBuilder();
 			if (dollar) {
 				sb.append("$");
-				sb.append(((StringLiteral) name).value().asText());
+				sb.append(((StringLiteral) name).value().asString());
 			} else {
 				sb.append(name);
 			}
@@ -62,7 +62,7 @@ public class ObjectMatcher implements PatternMatcher {
 
 		public PatternMatcher matcher() {
 			if (matcher == null)
-				return new ValueMatcher(((StringLiteral) name).value().asText());
+				return new ValueMatcher(((StringLiteral) name).value().asString());
 			return matcher;
 		}
 	}
@@ -75,14 +75,14 @@ public class ObjectMatcher implements PatternMatcher {
 
 		final FieldMatcher fmatcher = matchers.get(index);
 		fmatcher.name.apply(scope, in, (key) -> {
-			if (!key.isTextual())
+			if (!key.isString())
 				throw new JsonQueryTypeException("Cannot index %s with %s", in.getNodeType(), key.getNodeType());
 
-			final JsonNode value = in.get(key.asText());
+			final JsonNode value = in.get(key.asString());
 
 			final int size = accumulate.size();
 			if (fmatcher.dollar)
-				accumulate.push(Pair.of(key.asText(), value));
+				accumulate.push(Pair.of(key.asString(), value));
 			fmatcher.matcher().match(scope, value != null ? value : NullNode.getInstance(), (match) -> {
 				recursive(scope, in, out, accumulate, index + 1);
 			}, accumulate);
@@ -98,15 +98,15 @@ public class ObjectMatcher implements PatternMatcher {
 
 		final FieldMatcher fmatcher = matchers.get(index);
 		fmatcher.name.apply(scope, in, (key) -> {
-			if (!key.isTextual())
+			if (!key.isString())
 				throw new JsonQueryTypeException("Cannot index %s with %s", in.getNodeType(), key.getNodeType());
 
-			final JsonNode value = in.get(key.asText());
-			final Path valuepath = ObjectFieldPath.chainIfNotNull(inpath, key.asText());
+			final JsonNode value = in.get(key.asString());
+			final Path valuepath = ObjectFieldPath.chainIfNotNull(inpath, key.asString());
 
 			final int size = accumulate.size();
 			if (fmatcher.dollar)
-				accumulate.push(new MatchWithPath(key.asText(), value, valuepath));
+				accumulate.push(new MatchWithPath(key.asString(), value, valuepath));
 			fmatcher.matcher().matchWithPath(scope, value != null ? value : NullNode.getInstance(), valuepath, (match) -> {
 				recursiveWithPath(scope, in, inpath, output, accumulate, index + 1);
 			}, accumulate);

--- a/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/tree/matcher/matchers/ValueMatcher.java
+++ b/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/tree/matcher/matchers/ValueMatcher.java
@@ -3,7 +3,7 @@ package net.thisptr.jackson.jq.internal.tree.matcher.matchers;
 import java.util.List;
 import java.util.Stack;
 
-import com.fasterxml.jackson.databind.JsonNode;
+import tools.jackson.databind.JsonNode;
 
 import net.thisptr.jackson.jq.Scope;
 import net.thisptr.jackson.jq.exception.JsonQueryException;

--- a/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/utils/ExpressionUtils.java
+++ b/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/utils/ExpressionUtils.java
@@ -2,10 +2,10 @@ package net.thisptr.jackson.jq.internal.utils;
 
 import java.util.List;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.ArrayNode;
-import com.fasterxml.jackson.databind.node.ObjectNode;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.node.ArrayNode;
+import tools.jackson.databind.node.ObjectNode;
 
 import net.thisptr.jackson.jq.Expression;
 import net.thisptr.jackson.jq.internal.tree.ArrayConstruction;
@@ -46,7 +46,7 @@ public class ExpressionUtils {
 					final StringKeyFieldConstruction f = (StringKeyFieldConstruction) field;
 					if (!(f.key instanceof StringLiteral)) // then the key is string interpolation and not a constant
 						return null;
-					final String k = ((StringLiteral) f.key).value().asText();
+					final String k = ((StringLiteral) f.key).value().asString();
 
 					final JsonNode v = evaluateLiteralExpression(f.value);
 					if (v == null)

--- a/jackson-jq/src/main/java/net/thisptr/jackson/jq/module/ModuleLoader.java
+++ b/jackson-jq/src/main/java/net/thisptr/jackson/jq/module/ModuleLoader.java
@@ -1,6 +1,6 @@
 package net.thisptr.jackson.jq.module;
 
-import com.fasterxml.jackson.databind.JsonNode;
+import tools.jackson.databind.JsonNode;
 
 import net.thisptr.jackson.jq.exception.JsonQueryException;
 import net.thisptr.jackson.jq.internal.annotations.Experimental;

--- a/jackson-jq/src/main/java/net/thisptr/jackson/jq/module/loaders/BuiltinModuleLoader.java
+++ b/jackson-jq/src/main/java/net/thisptr/jackson/jq/module/loaders/BuiltinModuleLoader.java
@@ -4,7 +4,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.ServiceLoader;
 
-import com.fasterxml.jackson.databind.JsonNode;
+import tools.jackson.databind.JsonNode;
 
 import net.thisptr.jackson.jq.exception.JsonQueryException;
 import net.thisptr.jackson.jq.internal.annotations.Experimental;

--- a/jackson-jq/src/main/java/net/thisptr/jackson/jq/module/loaders/ChainedModuleLoader.java
+++ b/jackson-jq/src/main/java/net/thisptr/jackson/jq/module/loaders/ChainedModuleLoader.java
@@ -1,6 +1,6 @@
 package net.thisptr.jackson.jq.module.loaders;
 
-import com.fasterxml.jackson.databind.JsonNode;
+import tools.jackson.databind.JsonNode;
 
 import net.thisptr.jackson.jq.exception.JsonQueryException;
 import net.thisptr.jackson.jq.internal.annotations.Experimental;

--- a/jackson-jq/src/main/java/net/thisptr/jackson/jq/module/loaders/FileSystemModuleLoader.java
+++ b/jackson-jq/src/main/java/net/thisptr/jackson/jq/module/loaders/FileSystemModuleLoader.java
@@ -14,11 +14,11 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.ConcurrentHashMap;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.MappingIterator;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.ArrayNode;
-import com.fasterxml.jackson.databind.node.NullNode;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.MappingIterator;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.node.ArrayNode;
+import tools.jackson.databind.node.NullNode;
 
 import net.thisptr.jackson.jq.Expression;
 import net.thisptr.jackson.jq.Scope;
@@ -193,10 +193,10 @@ public class FileSystemModuleLoader implements ModuleLoader {
 					throw new JsonQueryException("search path can only be overriden from imported modules, but not from a top-level unnamed module");
 
 				// jq does ignore non-textual search overrides, but i want it to fail fast.
-				if (!search.isTextual())
+				if (!search.isString())
 					throw new JsonQueryException("search path overrides must be a string");
 
-				Path searchPathOverride = callerModule.modulePath.getFileSystem().getPath(search.asText());
+				Path searchPathOverride = callerModule.modulePath.getFileSystem().getPath(search.asString());
 				searchPathOverride = callerModule.modulePath.getParent().resolve(searchPathOverride).normalize();
 
 				// still, the search path must be within the original search path
@@ -272,7 +272,7 @@ public class FileSystemModuleLoader implements ModuleLoader {
 
 		final ArrayNode data = MAPPER.createArrayNode();
 
-		final MappingIterator<JsonNode> iter = MAPPER.readValues(MAPPER.getFactory().createParser(moduleFile.bytes), JsonNode.class);
+		final MappingIterator<JsonNode> iter = MAPPER.readValues(MAPPER.createParser(moduleFile.bytes), JsonNode.class);
 		while (iter.hasNext())
 			data.add(iter.next());
 

--- a/jackson-jq/src/main/java/net/thisptr/jackson/jq/path/ArrayIndexOfPath.java
+++ b/jackson-jq/src/main/java/net/thisptr/jackson/jq/path/ArrayIndexOfPath.java
@@ -1,9 +1,9 @@
 package net.thisptr.jackson.jq.path;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.ArrayNode;
-import com.fasterxml.jackson.databind.node.IntNode;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.node.ArrayNode;
+import tools.jackson.databind.node.IntNode;
 
 import net.thisptr.jackson.jq.PathOutput;
 import net.thisptr.jackson.jq.exception.JsonQueryException;

--- a/jackson-jq/src/main/java/net/thisptr/jackson/jq/path/ArrayIndexPath.java
+++ b/jackson-jq/src/main/java/net/thisptr/jackson/jq/path/ArrayIndexPath.java
@@ -1,10 +1,10 @@
 package net.thisptr.jackson.jq.path;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.ArrayNode;
-import com.fasterxml.jackson.databind.node.IntNode;
-import com.fasterxml.jackson.databind.node.NullNode;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.node.ArrayNode;
+import tools.jackson.databind.node.IntNode;
+import tools.jackson.databind.node.NullNode;
 
 import net.thisptr.jackson.jq.PathOutput;
 import net.thisptr.jackson.jq.exception.JsonQueryException;
@@ -91,11 +91,17 @@ public class ArrayIndexPath implements Path {
 	public static void resolve(final JsonNode pobj, final Path ppath, final PathOutput output, final JsonNode index, final boolean permissive) throws JsonQueryException {
 		assert index.isNumber();
 		if (pobj.isArray()) {
-			final int indexAsInt = index.asInt();
-			if (index.asDouble() != indexAsInt) { // if index is not an integer, emit null
+			final double indexAsDouble = index.asDouble();
+			if (indexAsDouble < Integer.MIN_VALUE || indexAsDouble > Integer.MAX_VALUE) { // if index is not an integer, emit null
 				output.emit(NullNode.getInstance(), ArrayIndexPath.chainIfNotNull(ppath, index));
 				return;
 			}
+            final int indexAsInt = index.asInt();
+            if (indexAsDouble != indexAsInt) {
+                output.emit(NullNode.getInstance(), ArrayIndexPath.chainIfNotNull(ppath, index));
+                return;
+            }
+
 			final int indexResolved = indexAsInt < 0 ? indexAsInt + pobj.size() : indexAsInt;
 			if (indexResolved < 0 || pobj.size() <= indexResolved) { // out of range index
 				output.emit(NullNode.getInstance(), ArrayIndexPath.chainIfNotNull(ppath, index));

--- a/jackson-jq/src/main/java/net/thisptr/jackson/jq/path/ArrayRangeIndexPath.java
+++ b/jackson-jq/src/main/java/net/thisptr/jackson/jq/path/ArrayRangeIndexPath.java
@@ -1,11 +1,11 @@
 package net.thisptr.jackson.jq.path;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.ArrayNode;
-import com.fasterxml.jackson.databind.node.NullNode;
-import com.fasterxml.jackson.databind.node.ObjectNode;
-import com.fasterxml.jackson.databind.node.TextNode;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.node.ArrayNode;
+import tools.jackson.databind.node.NullNode;
+import tools.jackson.databind.node.ObjectNode;
+import tools.jackson.databind.node.StringNode;
 
 import net.thisptr.jackson.jq.PathOutput;
 import net.thisptr.jackson.jq.exception.JsonQueryException;
@@ -91,7 +91,7 @@ public class ArrayRangeIndexPath implements Path {
 				out.add(in.get((int) index));
 
 			return out;
-		} else if (in.isTextual()) {
+		} else if (in.isString()) {
 			throw new JsonQueryException("Cannot update field at object index of string");
 		} else if (in.isNull()) {
 			final JsonNode newval = mutation.apply(NullNode.getInstance());
@@ -112,9 +112,9 @@ public class ArrayRangeIndexPath implements Path {
 			for (long index = r.start; index < r.end; ++index)
 				subarray.add(pobj.get((int) index));
 			output.emit(subarray, ArrayRangeIndexPath.chainIfNotNull(ppath, start, end));
-		} else if (pobj.isTextual()) {
-			final Range r = Range.resolve(start, end, UnicodeUtils.lengthUtf32(pobj.textValue()));
-			final TextNode substring = new TextNode(UnicodeUtils.substringUtf32(pobj.textValue(), (int) r.start, (int) r.end));
+		} else if (pobj.isString()) {
+			final Range r = Range.resolve(start, end, UnicodeUtils.lengthUtf32(pobj.stringValue()));
+			final StringNode substring = new StringNode(UnicodeUtils.substringUtf32(pobj.stringValue(), (int) r.start, (int) r.end));
 			output.emit(substring, ArrayRangeIndexPath.chainIfNotNull(ppath, start, end));
 		} else if (pobj.isNull()) {
 			output.emit(NullNode.getInstance(), ArrayRangeIndexPath.chainIfNotNull(ppath, start, end));

--- a/jackson-jq/src/main/java/net/thisptr/jackson/jq/path/InvalidPath.java
+++ b/jackson-jq/src/main/java/net/thisptr/jackson/jq/path/InvalidPath.java
@@ -1,7 +1,7 @@
 package net.thisptr.jackson.jq.path;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.ArrayNode;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.node.ArrayNode;
 
 import net.thisptr.jackson.jq.PathOutput;
 import net.thisptr.jackson.jq.exception.JsonQueryException;

--- a/jackson-jq/src/main/java/net/thisptr/jackson/jq/path/ObjectFieldPath.java
+++ b/jackson-jq/src/main/java/net/thisptr/jackson/jq/path/ObjectFieldPath.java
@@ -1,14 +1,13 @@
 package net.thisptr.jackson.jq.path;
 
-import java.util.Iterator;
 import java.util.Map.Entry;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.ArrayNode;
-import com.fasterxml.jackson.databind.node.NullNode;
-import com.fasterxml.jackson.databind.node.ObjectNode;
-import com.fasterxml.jackson.databind.node.TextNode;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.node.ArrayNode;
+import tools.jackson.databind.node.NullNode;
+import tools.jackson.databind.node.ObjectNode;
+import tools.jackson.databind.node.StringNode;
 
 import net.thisptr.jackson.jq.PathOutput;
 import net.thisptr.jackson.jq.exception.JsonQueryException;
@@ -34,7 +33,7 @@ public class ObjectFieldPath implements Path {
 	@Override
 	public void toJsonNode(final ArrayNode out) throws JsonQueryException {
 		parent.toJsonNode(out);
-		out.add(new TextNode(key));
+		out.add(new StringNode(key));
 	}
 
 	@Override
@@ -61,9 +60,7 @@ public class ObjectFieldPath implements Path {
 		}
 		if (in.isObject()) {
 			final ObjectNode newobj = MAPPER.createObjectNode();
-			final Iterator<Entry<String, JsonNode>> iter = in.fields();
-			while (iter.hasNext()) {
-				final Entry<String, JsonNode> entry = iter.next();
+			for (final Entry<String, JsonNode> entry : in.properties()) {
 				newobj.set(entry.getKey(), entry.getValue());
 			}
 			final JsonNode newval = mutation.apply(newobj.get(key));

--- a/jackson-jq/src/main/java/net/thisptr/jackson/jq/path/Path.java
+++ b/jackson-jq/src/main/java/net/thisptr/jackson/jq/path/Path.java
@@ -1,7 +1,7 @@
 package net.thisptr.jackson.jq.path;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.ArrayNode;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.node.ArrayNode;
 
 import net.thisptr.jackson.jq.PathOutput;
 import net.thisptr.jackson.jq.exception.JsonQueryException;

--- a/jackson-jq/src/main/java/net/thisptr/jackson/jq/path/RootPath.java
+++ b/jackson-jq/src/main/java/net/thisptr/jackson/jq/path/RootPath.java
@@ -1,7 +1,7 @@
 package net.thisptr.jackson.jq.path;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.ArrayNode;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.node.ArrayNode;
 
 import net.thisptr.jackson.jq.PathOutput;
 import net.thisptr.jackson.jq.exception.JsonQueryException;

--- a/jackson-jq/src/main/javacc/json-query.jj
+++ b/jackson-jq/src/main/javacc/json-query.jj
@@ -292,7 +292,7 @@ ImportStatement ImportStatement():
 	{
 		if (!(pathExpr instanceof StringLiteral))
 			throw new IllegalStateException("Import path must be constant");
-		path = ((StringLiteral) pathExpr).value().asText();
+		path = ((StringLiteral) pathExpr).value().asString();
 	}
 	<KEYWORD_AS>
 	(
@@ -320,7 +320,7 @@ ImportStatement IncludeStatement():
 	{
 		if (!(pathExpr instanceof StringLiteral))
 			throw new IllegalStateException("Include path must be constant");
-		path = ((StringLiteral) pathExpr).value().asText();
+		path = ((StringLiteral) pathExpr).value().asString();
 	}
 	(
 		metadata = Expression()

--- a/jackson-jq/src/test/java/examples/Usage.java
+++ b/jackson-jq/src/test/java/examples/Usage.java
@@ -7,10 +7,10 @@ import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.IntNode;
-import com.fasterxml.jackson.databind.node.TextNode;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.node.IntNode;
+import tools.jackson.databind.node.StringNode;
 
 import net.thisptr.jackson.jq.BuiltinFunctionLoader;
 import net.thisptr.jackson.jq.Expression;
@@ -46,7 +46,7 @@ public class Usage {
 			@Override
 			public void apply(Scope scope, List<Expression> args, JsonNode in, Path path, PathOutput output, Version version) throws JsonQueryException {
 				args.get(0).apply(scope, in, (time) -> {
-					output.emit(new TextNode(Strings.repeat(in.asText(), time.asInt())), null);
+					output.emit(new StringNode(Strings.repeat(in.asString(), time.asInt())), null);
 				});
 			}
 		});

--- a/jackson-jq/src/test/java/net/thisptr/jackson/jq/CustomFunctionTest.java
+++ b/jackson-jq/src/test/java/net/thisptr/jackson/jq/CustomFunctionTest.java
@@ -1,9 +1,9 @@
 package net.thisptr.jackson.jq;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.IntNode;
-import com.fasterxml.jackson.databind.node.ObjectNode;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.node.IntNode;
+import tools.jackson.databind.node.ObjectNode;
 import net.thisptr.jackson.jq.exception.JsonQueryException;
 import net.thisptr.jackson.jq.path.Path;
 import org.junit.jupiter.api.Test;

--- a/jackson-jq/src/test/java/net/thisptr/jackson/jq/JsonNodeComparatorForTests.java
+++ b/jackson-jq/src/test/java/net/thisptr/jackson/jq/JsonNodeComparatorForTests.java
@@ -3,7 +3,7 @@ package net.thisptr.jackson.jq;
 import java.util.Iterator;
 import java.util.Map.Entry;
 
-import com.fasterxml.jackson.databind.JsonNode;
+import tools.jackson.databind.JsonNode;
 
 import net.thisptr.jackson.jq.internal.misc.JsonNodeComparator;
 
@@ -28,8 +28,8 @@ public class JsonNodeComparatorForTests extends JsonNodeComparator {
 	@Override
 	protected int compareObjectNode(final JsonNode o1, final JsonNode o2) {
 		if (strictFieldOrder) {
-			final Iterator<Entry<String, JsonNode>> it1 = o1.fields();
-			final Iterator<Entry<String, JsonNode>> it2 = o2.fields();
+			final Iterator<Entry<String, JsonNode>> it1 = o1.properties().iterator();
+			final Iterator<Entry<String, JsonNode>> it2 = o2.properties().iterator();
 			while (it1.hasNext() && it2.hasNext()) {
 				final Entry<String, JsonNode> entry1 = it1.next();
 				final Entry<String, JsonNode> entry2 = it2.next();

--- a/jackson-jq/src/test/java/net/thisptr/jackson/jq/JsonQueryTest.java
+++ b/jackson-jq/src/test/java/net/thisptr/jackson/jq/JsonQueryTest.java
@@ -7,12 +7,12 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
-import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.annotation.JsonDeserialize;
+import tools.jackson.databind.annotation.JsonSerialize;
+import tools.jackson.databind.ser.std.ToStringSerializer;
+import tools.jackson.dataformat.yaml.YAMLMapper;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
@@ -125,13 +125,7 @@ public class JsonQueryTest {
 		testCases.addAll(loadTestCasesDirectory("tests", false));
 		testCases.addAll(loadTestCasesDirectory("failing_tests", true));
 
-		return testCases.stream().map(a -> {
-			try {
-				return JSON_MAPPER.writeValueAsString(a);
-			} catch (final IOException e) {
-				throw new RuntimeException(e);
-			}
-		});
+		return testCases.stream().map(JSON_MAPPER::writeValueAsString);
 	}
 
 	private static Map<Version, Boolean> hasJqCache = new ConcurrentHashMap<>();

--- a/jackson-jq/src/test/java/net/thisptr/jackson/jq/JsonQueryTest.java
+++ b/jackson-jq/src/test/java/net/thisptr/jackson/jq/JsonQueryTest.java
@@ -58,16 +58,16 @@ public class JsonQueryTest {
 		public Boolean failing;
 
 		@JsonProperty("should_compile")
-		public boolean shouldCompile = true;
+		public Boolean shouldCompile = true;
 
 		@JsonProperty("ignore_true_jq_behavior")
-		public boolean ignoreTrueJqBehavior = false;
+		public Boolean ignoreTrueJqBehavior = false;
 
 		@JsonProperty("numerical_errors")
-		public double numericalErrors = 0;
+		public Double numericalErrors = 0.0;
 
 		@JsonProperty("ignore_field_order")
-		public boolean ignoreFieldOrder = false;
+		public Boolean ignoreFieldOrder = false;
 
 		@JsonInclude(Include.NON_NULL)
 		@JsonProperty("v")

--- a/jackson-jq/src/test/java/net/thisptr/jackson/jq/internal/JsonQueryFunctionTest.java
+++ b/jackson-jq/src/test/java/net/thisptr/jackson/jq/internal/JsonQueryFunctionTest.java
@@ -9,10 +9,10 @@ import java.util.List;
 
 import org.junit.jupiter.api.Test;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.IntNode;
-import com.fasterxml.jackson.databind.node.NullNode;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.node.IntNode;
+import tools.jackson.databind.node.NullNode;
 
 import net.thisptr.jackson.jq.BuiltinFunctionLoader;
 import net.thisptr.jackson.jq.JsonQuery;

--- a/jackson-jq/src/test/java/net/thisptr/jackson/jq/internal/NullLHSFunctionTest.java
+++ b/jackson-jq/src/test/java/net/thisptr/jackson/jq/internal/NullLHSFunctionTest.java
@@ -11,11 +11,11 @@ import javax.management.ObjectName;
 
 import org.junit.jupiter.api.Test;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.IntNode;
-import com.fasterxml.jackson.databind.node.NullNode;
-import com.fasterxml.jackson.databind.node.ObjectNode;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.node.IntNode;
+import tools.jackson.databind.node.NullNode;
+import tools.jackson.databind.node.ObjectNode;
 
 import net.thisptr.jackson.jq.BuiltinFunctionLoader;
 import net.thisptr.jackson.jq.JsonQuery;

--- a/jackson-jq/src/test/java/net/thisptr/jackson/jq/internal/misc/JsonNodeComparatorTest.java
+++ b/jackson-jq/src/test/java/net/thisptr/jackson/jq/internal/misc/JsonNodeComparatorTest.java
@@ -10,8 +10,8 @@ import java.util.List;
 
 import org.junit.jupiter.api.Test;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
 
 public class JsonNodeComparatorTest {
 

--- a/jackson-jq/src/test/java/net/thisptr/jackson/jq/internal/tree/matcher/matchers/ObjectMatcherTest.java
+++ b/jackson-jq/src/test/java/net/thisptr/jackson/jq/internal/tree/matcher/matchers/ObjectMatcherTest.java
@@ -9,9 +9,9 @@ import java.util.Stack;
 
 import org.junit.jupiter.api.Test;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.IntNode;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.node.IntNode;
 
 import net.thisptr.jackson.jq.Scope;
 import net.thisptr.jackson.jq.Versions;

--- a/jackson-jq/src/test/java/net/thisptr/jackson/jq/module/loaders/FileSystemModuleLoaderTest.java
+++ b/jackson-jq/src/test/java/net/thisptr/jackson/jq/module/loaders/FileSystemModuleLoaderTest.java
@@ -3,9 +3,9 @@ package net.thisptr.jackson.jq.module.loaders;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.IntNode;
-import com.fasterxml.jackson.databind.node.NullNode;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.node.IntNode;
+import tools.jackson.databind.node.NullNode;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;

--- a/jackson-jq/src/test/java/net/thisptr/jackson/jq/random/EmptyExpression.java
+++ b/jackson-jq/src/test/java/net/thisptr/jackson/jq/random/EmptyExpression.java
@@ -1,6 +1,6 @@
 package net.thisptr.jackson.jq.random;
 
-import com.fasterxml.jackson.databind.JsonNode;
+import tools.jackson.databind.JsonNode;
 
 import net.thisptr.jackson.jq.Expression;
 import net.thisptr.jackson.jq.PathOutput;

--- a/jackson-jq/src/test/java/net/thisptr/jackson/jq/random/LiteralExpression.java
+++ b/jackson-jq/src/test/java/net/thisptr/jackson/jq/random/LiteralExpression.java
@@ -1,6 +1,6 @@
 package net.thisptr.jackson.jq.random;
 
-import com.fasterxml.jackson.databind.JsonNode;
+import tools.jackson.databind.JsonNode;
 
 import net.thisptr.jackson.jq.Expression;
 import net.thisptr.jackson.jq.PathOutput;

--- a/jackson-jq/src/test/java/net/thisptr/jackson/jq/random/RandomTest.java
+++ b/jackson-jq/src/test/java/net/thisptr/jackson/jq/random/RandomTest.java
@@ -20,12 +20,12 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import com.fasterxml.jackson.databind.node.NullNode;
-import com.fasterxml.jackson.databind.node.TextNode;
-import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.annotation.JsonSerialize;
+import tools.jackson.databind.node.NullNode;
+import tools.jackson.databind.node.StringNode;
+import tools.jackson.databind.ser.std.ToStringSerializer;
 
 import net.thisptr.jackson.jq.BuiltinFunctionLoader;
 import net.thisptr.jackson.jq.Expression;
@@ -213,7 +213,7 @@ public class RandomTest {
 				if (expected.error != null) {
 					test.expression = new TryCatch(expr, new StringLiteral("__ERROR__"));
 					test.out = new ArrayList<>(expected.values);
-					test.out.add(TextNode.valueOf("__ERROR__"));
+					test.out.add(StringNode.valueOf("__ERROR__"));
 				} else {
 					test.expression = expr;
 					test.out = expected.values;

--- a/jackson-jq/src/test/java/net/thisptr/jackson/jq/test/evaluator/CachedEvaluator.java
+++ b/jackson-jq/src/test/java/net/thisptr/jackson/jq/test/evaluator/CachedEvaluator.java
@@ -10,10 +10,10 @@ import org.rocksdb.RocksDB;
 import org.rocksdb.RocksDBException;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.annotation.JsonSerialize;
+import tools.jackson.databind.ser.std.ToStringSerializer;
 
 import net.thisptr.jackson.jq.Version;
 
@@ -90,7 +90,7 @@ public class CachedEvaluator implements AutoCloseable, Evaluator {
 					value.error = "null";
 			}
 			db.put(key, MAPPER.writeValueAsBytes(value));
-		} catch (IOException | RocksDBException e) {
+		} catch (RocksDBException e) {
 			throw new RuntimeException(e);
 		}
 	}
@@ -103,7 +103,7 @@ public class CachedEvaluator implements AutoCloseable, Evaluator {
 				return null;
 			final CachedEvaluator.Value value = MAPPER.readValue(bytes, CachedEvaluator.Value.class);
 			return new Result(value.out, value.error != null ? new RuntimeException(value.error) : null);
-		} catch (final IOException | RocksDBException e) {
+		} catch (final RocksDBException e) {
 			throw new RuntimeException(e);
 		}
 	}

--- a/jackson-jq/src/test/java/net/thisptr/jackson/jq/test/evaluator/Evaluator.java
+++ b/jackson-jq/src/test/java/net/thisptr/jackson/jq/test/evaluator/Evaluator.java
@@ -2,7 +2,7 @@ package net.thisptr.jackson.jq.test.evaluator;
 
 import java.util.List;
 
-import com.fasterxml.jackson.databind.JsonNode;
+import tools.jackson.databind.JsonNode;
 
 import net.thisptr.jackson.jq.Version;
 

--- a/jackson-jq/src/test/java/net/thisptr/jackson/jq/test/evaluator/JacksonJqEvaluator.java
+++ b/jackson-jq/src/test/java/net/thisptr/jackson/jq/test/evaluator/JacksonJqEvaluator.java
@@ -5,9 +5,9 @@ import java.util.List;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicReference;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.DoubleNode;
-import com.fasterxml.jackson.databind.node.NullNode;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.node.DoubleNode;
+import tools.jackson.databind.node.NullNode;
 
 import net.thisptr.jackson.jq.DefaultRootScope;
 import net.thisptr.jackson.jq.Expression;

--- a/jackson-jq/src/test/java/net/thisptr/jackson/jq/test/evaluator/TrueJqEvaluator.java
+++ b/jackson-jq/src/test/java/net/thisptr/jackson/jq/test/evaluator/TrueJqEvaluator.java
@@ -15,10 +15,10 @@ import java.util.concurrent.TimeoutException;
 
 import org.junit.jupiter.api.Test;
 
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.MappingIterator;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.core.JsonParser;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.MappingIterator;
+import tools.jackson.databind.ObjectMapper;
 import com.google.common.io.ByteStreams;
 
 import net.thisptr.jackson.jq.Version;
@@ -63,7 +63,7 @@ public class TrueJqEvaluator implements Evaluator {
 
 		final List<JsonNode> values = new ArrayList<>();
 		try (final InputStream stdout = p.getInputStream()) {
-			final JsonParser parser = MAPPER.getFactory().createParser(ByteStreams.toByteArray(stdout));
+			final JsonParser parser = MAPPER.createParser(ByteStreams.toByteArray(stdout));
 			final MappingIterator<JsonNode> iter = MAPPER.readValues(parser, JsonNode.class);
 			while (iter.hasNextValue()) {
 				values.add(iter.nextValue());

--- a/jackson-jq/src/test/resources/META-INF/native-image/reflect-config.json
+++ b/jackson-jq/src/test/resources/META-INF/native-image/reflect-config.json
@@ -39,7 +39,7 @@
 		}
 	},
 	{
-		"name": "com.fasterxml.jackson.databind.ser.std.ToStringSerializer",
+		"name": "tools.jackson.databind.ser.std.ToStringSerializer",
 		"methods": [
 			{
 				"name": "<init>",

--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
 
 	<properties>
 		<org.slf4j-version>2.0.17</org.slf4j-version>
-		<com.fasterxml.jackson-version>2.19.2</com.fasterxml.jackson-version>
+		<tools.jackson-version>3.0.3</tools.jackson-version>
 		<com.google.auto.service-version>1.1.1</com.google.auto.service-version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 	</properties>
@@ -54,9 +54,9 @@
 	<dependencyManagement>
 		<dependencies>
 			<dependency>
-				<groupId>com.fasterxml.jackson</groupId>
+				<groupId>tools.jackson</groupId>
 				<artifactId>jackson-bom</artifactId>
-				<version>${com.fasterxml.jackson-version}</version>
+				<version>${tools.jackson-version}</version>
 				<type>pom</type>
 				<scope>import</scope>
 			</dependency>
@@ -122,8 +122,8 @@
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
 				<configuration>
-					<source>1.8</source>
-					<target>1.8</target>
+					<source>17</source>
+					<target>17</target>
 					<compilerArgument>-Xlint:all,-processing</compilerArgument>
 					<showWarnings>true</showWarnings>
 					<showDeprecation>true</showDeprecation>


### PR DESCRIPTION
Issue ref: https://github.com/eiiches/jackson-jq/issues/515

Maven Dependencies (pom.xml files):
  • Changed Jackson BOM groupId from com.fasterxml.jackson to tools.jackson
  • Updated Jackson version to 3.0.3
  • Updated Java source/target from 1.8 to 17

Java Package Changes
  • Updated all imports from com.fasterxml.jackson to tools.jackson (except annotations)

Key API Changes Fixed
  1. TextNode → StringNode
  2. fields() → properties()
  3. fieldNames() → propertyNames()
  4. getFactory() → tokenStreamFactory()
  5. ObjectMapper.registerModule() → JsonMapper.builder().addModule().build()
  6. JsonSerializer → ValueSerializer:
  7. JsonDeserializer → ValueDeserializer
  8. writeObjectField() → writePOJOProperty()
  9. tokenStreamFactory().createParser() → ObjectMapper.createParser()
  10. IOException removal: Removed unnecessary IOException declarations and catches

Behavioral Changes Fixed
  1. Stricter numeric conversions: Fixed longValue(), asInt(), asLong() to avoid exceptions on NaN, fractional, or out-of-range values
  2. NullNode.asText(): Fixed string interpolation to return "null" instead of empty string
  3. Field ordering: Added @JsonPropertyOrder annotations to preserve expected field order in serialization - one of the tests was failing.