### PR TITLE
ci: setup CI workflows for 2.x branch

### DIFF
--- a/.github/workflows/deploy-snapshot.yaml
+++ b/.github/workflows/deploy-snapshot.yaml
@@ -3,7 +3,7 @@ name: 'test'
 on:
   push:
     branches:
-    - develop/1.x
+    - develop/2.x
 jobs:
   build:
     runs-on: ubuntu-22.04

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -64,7 +64,7 @@ jobs:
         MAVEN_GPG_PASSPHRASE: ${{ secrets.MAVEN_GPG_PASSPHRASE }}
       run: |
         set -euo pipefail
-        git checkout master/1.x
+        git checkout master/2.x
         PATH="$HOME/bin:$PATH" mvn -Prelease clean deploy
 
     - name: Git Push

--- a/.github/workflows/test-pull-requests.yaml
+++ b/.github/workflows/test-pull-requests.yaml
@@ -2,7 +2,7 @@ name: 'test-pull-requests'
 on:
   pull_request:
     branches:
-    - develop/1.x
+    - develop/2.x
 jobs:
   build:
     runs-on: ubuntu-22.04


### PR DESCRIPTION
This pull request updates the CI/CD GitHub Actions workflows to target the new `2.x` development and master branches instead of the previous `1.x` branches. This ensures that all automated testing, deployment, and release processes are aligned with the current main line of development.

**Workflow branch updates:**

- Updated the `deploy-snapshot.yaml` workflow to trigger on pushes to the `develop/2.x` branch instead of `develop/1.x`.
- Updated the `test-pull-requests.yaml` workflow to trigger on pull requests targeting the `develop/2.x` branch instead of `develop/1.x`.
- Changed the `release.yaml` workflow to check out the `master/2.x` branch instead of `master/1.x` during the release process.