### PR TITLE
ci: fix deploy-snapshot workflow

### DIFF
--- a/.github/workflows/deploy-snapshot.yaml
+++ b/.github/workflows/deploy-snapshot.yaml
@@ -9,10 +9,10 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v5.0.0
-    - name: Set up JDK 1.8
+    - name: Set up JDK 17
       uses: actions/setup-java@v5.0.0
       with:
-        java-version: '8'
+        java-version: '17'
         distribution: 'temurin'
 
     - name: Download jq-1.5 and jq-1.6


### PR DESCRIPTION
This pull request updates the Java development environment used in the deployment workflow to a more recent version. The change ensures that future builds use JDK 17 instead of the older JDK 8.

Environment update:

* Updated the deployment workflow in `.github/workflows/deploy-snapshot.yaml` to use JDK 17 (Temurin) instead of JDK 8 for the `Set up JDK` step.