### PR TITLE
ci: fix release script for v2

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -12,8 +12,8 @@ cd "$scriptdir/.."
 
 version="$1"
 next_version="$2"
-develop_branch=develop/1.x
-master_branch=master/1.x
+develop_branch=develop/2.x
+master_branch=master/2.x
 release_branch=release/$version
 tag_name=$version
 


### PR DESCRIPTION
This pull request updates the release script to use the correct branch names for version 2.x. The only change is updating the `develop_branch` and `master_branch` variables to point to `develop/2.x` and `master/2.x` instead of `develop/1.x` and `master/1.x`.

* Updated `develop_branch` and `master_branch` variables in `scripts/release.sh` to use `develop/2.x` and `master/2.x` for version 2.x releases.