### PR TITLE
ci: fix release script for v2; upgrade jdk to 17

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -17,10 +17,10 @@ jobs:
       with:
         fetch-depth: 0
 
-    - name: Set up JDK 1.8
+    - name: Set up JDK 17
       uses: actions/setup-java@v5.0.0
       with:
-        java-version: '8'
+        java-version: '17'
         distribution: 'temurin'
 
     - name: Download jq-1.5 and jq-1.6


### PR DESCRIPTION
This pull request updates the Java version used in the GitHub Actions release workflow to JDK 17. This ensures the workflow runs with a more modern and supported Java runtime.

- CI/CD workflow update:
  * [`.github/workflows/release.yaml`](diffhunk://#diff-e426ed45842837026e10e66af23d9c7077e89eacbe6958ce7cb991130ad05adaL20-R23): Changed the Java setup step to use JDK 17 instead of JDK 1.8.

Context: Jackson 3 requires JDK 17.