### PR TITLE
Fix StackOverflowError in gsub/sub replacement concatenation

### DIFF
--- a/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/functions/_SubImplFunction.java
+++ b/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/functions/_SubImplFunction.java
@@ -1,7 +1,9 @@
 package net.thisptr.jackson.jq.internal.functions;
 
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayDeque;
 import java.util.ArrayList;
+import java.util.Deque;
 import java.util.List;
 
 import org.joni.Matcher;
@@ -52,31 +54,68 @@ public class _SubImplFunction implements Function {
 	}
 
 	private void replaceAndConcat(Scope scope, PathOutput output, List<JsonNode> match, Expression replaceExpr) throws JsonQueryException {
-		List<StringBuilder> results = new ArrayList<>();
-		results.add(new StringBuilder());
+		final Deque<Frame> frames = new ArrayDeque<>();
+		frames.push(new Frame(match.size() - 1, null, null));
 
-		for (final JsonNode segment : match) {
+		while (!frames.isEmpty()) {
+			final Frame frame = frames.pop();
+			if (frame.pendingException != null) {
+				throw frame.pendingException;
+			}
+			if (frame.index < 0) {
+				output.emit(new TextNode(concat(frame.parts)), null);
+				continue;
+			}
+
+			final JsonNode segment = match.get(frame.index);
 			if (segment.isTextual()) {
-				final String text = segment.textValue();
-				for (final StringBuilder result : results) {
-					result.append(text);
-				}
-			} else {
-				final List<String> replacements = new ArrayList<>();
-				replaceExpr.apply(scope, segment, replacement -> replacements.add(replacement.asText()));
+				frames.push(new Frame(frame.index - 1, new Part(segment.textValue(), frame.parts), null));
+				continue;
+			}
 
-				final List<StringBuilder> next = new ArrayList<>(results.size() * replacements.size());
-				for (final StringBuilder result : results) {
-					for (final String replacement : replacements) {
-						next.add(new StringBuilder(result).append(replacement));
-					}
-				}
-				results = next;
+			final List<String> replacements = new ArrayList<>();
+			JsonQueryException pendingException = null;
+			try {
+				replaceExpr.apply(scope, segment, replacement -> replacements.add(replacement.asText()));
+			} catch (final JsonQueryException e) {
+				pendingException = e;
+			}
+			if (pendingException != null) {
+				frames.push(new Frame(-1, null, pendingException));
+			}
+			for (int i = replacements.size() - 1; i >= 0; --i) {
+				frames.push(new Frame(frame.index - 1, new Part(replacements.get(i), frame.parts), null));
 			}
 		}
+	}
 
-		for (final StringBuilder result : results) {
-			output.emit(new TextNode(result.toString()), null);
+	private static String concat(final Part parts) {
+		final StringBuilder result = new StringBuilder();
+		for (Part part = parts; part != null; part = part.next) {
+			result.append(part.value);
+		}
+		return result.toString();
+	}
+
+	private static class Frame {
+		private final int index;
+		private final Part parts;
+		private final JsonQueryException pendingException;
+
+		private Frame(final int index, final Part parts, final JsonQueryException pendingException) {
+			this.index = index;
+			this.parts = parts;
+			this.pendingException = pendingException;
+		}
+	}
+
+	private static class Part {
+		private final String value;
+		private final Part next;
+
+		private Part(final String value, final Part next) {
+			this.value = value;
+			this.next = next;
 		}
 	}
 

--- a/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/functions/_SubImplFunction.java
+++ b/jackson-jq/src/main/java/net/thisptr/jackson/jq/internal/functions/_SubImplFunction.java
@@ -3,7 +3,6 @@ package net.thisptr.jackson.jq.internal.functions;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Stack;
 
 import org.joni.Matcher;
 import org.joni.Option;
@@ -46,35 +45,38 @@ public class _SubImplFunction implements Function {
 
 				// This just repeats same emit()s the number of times as the number of flags. This is to emulate jq behavior (which is probably a bug).
 				args.get(2).apply(scope, in, (dummy) -> {
-					replaceAndConcat(scope, new Stack<>(), output, match, args.get(1), in, args.get(2));
+					replaceAndConcat(scope, output, match, args.get(1));
 				});
 			});
 		});
 	}
 
-	private void replaceAndConcat(Scope scope, Stack<String> stack, PathOutput output, List<JsonNode> match, Expression replaceExpr, final JsonNode in, final Expression flags) throws JsonQueryException {
-		if (match.isEmpty()) {
-			final StringBuilder sb = new StringBuilder();
-			for (int i = stack.size() - 1; i >= 0; --i) {
-				sb.append(stack.get(i));
+	private void replaceAndConcat(Scope scope, PathOutput output, List<JsonNode> match, Expression replaceExpr) throws JsonQueryException {
+		List<StringBuilder> results = new ArrayList<>();
+		results.add(new StringBuilder());
+
+		for (final JsonNode segment : match) {
+			if (segment.isTextual()) {
+				final String text = segment.textValue();
+				for (final StringBuilder result : results) {
+					result.append(text);
+				}
+			} else {
+				final List<String> replacements = new ArrayList<>();
+				replaceExpr.apply(scope, segment, replacement -> replacements.add(replacement.asText()));
+
+				final List<StringBuilder> next = new ArrayList<>(results.size() * replacements.size());
+				for (final StringBuilder result : results) {
+					for (final String replacement : replacements) {
+						next.add(new StringBuilder(result).append(replacement));
+					}
+				}
+				results = next;
 			}
-			output.emit(new TextNode(sb.toString()), null);
-			return;
 		}
 
-		final JsonNode rhead = match.get(match.size() - 1);
-		final List<JsonNode> rtail = match.subList(0, match.size() - 1);
-
-		if (rhead.isTextual()) {
-			stack.push(rhead.textValue());
-			replaceAndConcat(scope, stack, output, rtail, replaceExpr, in, flags);
-			stack.pop();
-		} else {
-			replaceExpr.apply(scope, rhead, (replacement) -> {
-				stack.push(replacement.asText());
-				replaceAndConcat(scope, stack, output, rtail, replaceExpr, in, flags);
-				stack.pop();
-			});
+		for (final StringBuilder result : results) {
+			output.emit(new TextNode(result.toString()), null);
 		}
 	}
 

--- a/jackson-jq/src/test/java/net/thisptr/jackson/jq/internal/functions/SubImplFunctionTest.java
+++ b/jackson-jq/src/test/java/net/thisptr/jackson/jq/internal/functions/SubImplFunctionTest.java
@@ -26,8 +26,8 @@ public class SubImplFunctionTest {
 
 		assertThat(out).containsExactly(
 				TextNode.valueOf("xx"),
-				TextNode.valueOf("xy"),
 				TextNode.valueOf("yx"),
+				TextNode.valueOf("xy"),
 				TextNode.valueOf("yy"));
 	}
 
@@ -36,6 +36,38 @@ public class SubImplFunctionTest {
 		final List<JsonNode> out = apply("gsub(\"a\"; \"\")", repeat("a", 10000));
 
 		assertThat(out).containsExactly(TextNode.valueOf(""));
+	}
+
+	@Test
+	public void subEmitsSuccessfulReplacementBranchesBeforeReplacementError() throws Exception {
+		final List<JsonNode> out = apply("try sub(\"a\"; \"1\", \"2\", error(\"bar\"); \"g\") catch .", "abcabc");
+
+		assertThat(out).containsExactly(
+				TextNode.valueOf("1bc1bc"),
+				TextNode.valueOf("2bc1bc"),
+				TextNode.valueOf("bar"));
+	}
+
+	@Test
+	public void subEmitsSuccessfulReplacementBranchesBeforePatternError() throws Exception {
+		final List<JsonNode> out = apply("try sub(\"a\", \"b\", error(\"foo\"); \"1\", \"2\", error(\"bar\"); \"\", \"g\", error(\"baz\")) catch .", "abcabc");
+
+		assertThat(out).containsExactly(
+				TextNode.valueOf("1bcabc"),
+				TextNode.valueOf("2bcabc"),
+				TextNode.valueOf("bar"));
+	}
+
+	@Test
+	public void subEmitsSuccessfulReplacementBranchesBeforeFlagsError() throws Exception {
+		final List<JsonNode> out = apply("try sub(\"a\", \"b\", error(\"foo\"); \"1\", \"2\"; \"\", \"g\", error(\"baz\")) catch .", "abcabc");
+
+		assertThat(out).containsExactly(
+				TextNode.valueOf("1bcabc"),
+				TextNode.valueOf("2bcabc"),
+				TextNode.valueOf("1bcabc"),
+				TextNode.valueOf("2bcabc"),
+				TextNode.valueOf("baz"));
 	}
 
 	private static List<JsonNode> apply(final String queryText, final String input) throws Exception {

--- a/jackson-jq/src/test/java/net/thisptr/jackson/jq/internal/functions/SubImplFunctionTest.java
+++ b/jackson-jq/src/test/java/net/thisptr/jackson/jq/internal/functions/SubImplFunctionTest.java
@@ -1,0 +1,55 @@
+package net.thisptr.jackson.jq.internal.functions;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.TextNode;
+import net.thisptr.jackson.jq.DefaultRootScope;
+import net.thisptr.jackson.jq.JsonQuery;
+import net.thisptr.jackson.jq.Version;
+import org.junit.jupiter.api.Test;
+
+public class SubImplFunctionTest {
+	@Test
+	public void gsubUsesCaptureObjectsForReplacementExpression() throws Exception {
+		final List<JsonNode> out = apply("gsub(\"(?<d>\\\\d)\"; \"\\(.d|tonumber+1)\")", "a1b2");
+
+		assertThat(out).containsExactly(TextNode.valueOf("a2b3"));
+	}
+
+	@Test
+	public void gsubPreservesMultipleReplacementOutputs() throws Exception {
+		final List<JsonNode> out = apply("gsub(\"a\"; \"x\", \"y\")", "aa");
+
+		assertThat(out).containsExactly(
+				TextNode.valueOf("xx"),
+				TextNode.valueOf("xy"),
+				TextNode.valueOf("yx"),
+				TextNode.valueOf("yy"));
+	}
+
+	@Test
+	public void gsubHandlesManyMatchesWithoutStackOverflow() throws Exception {
+		final List<JsonNode> out = apply("gsub(\"a\"; \"\")", repeat("a", 10000));
+
+		assertThat(out).containsExactly(TextNode.valueOf(""));
+	}
+
+	private static List<JsonNode> apply(final String queryText, final String input) throws Exception {
+		final JsonQuery query = JsonQuery.compile(queryText, Version.LATEST);
+		final List<JsonNode> out = new ArrayList<>();
+		query.apply(DefaultRootScope.getInstance(Version.LATEST), TextNode.valueOf(input), out::add);
+		return out;
+	}
+
+	private static String repeat(final String text, final int count) {
+		final StringBuilder result = new StringBuilder(text.length() * count);
+		for (int i = 0; i < count; ++i) {
+			result.append(text);
+		}
+		return result.toString();
+	}
+}


### PR DESCRIPTION
Fixes #517.

_SubImplFunction.replaceAndConcat() currently builds substitution results recursively, consuming one Java stack frame per matched segment. For large inputs with many sub/gsub matches, this can overflow the stack even though the operation is otherwise straightforward.

This changes the replacement concatenation path to use an iterative prefix-expansion loop instead of recursion. It preserves existing behavior where a replacement expression may emit multiple values by expanding all accumulated prefixes with each emitted replacement.

Added regression coverage for:
- named capture replacement expressions
- multi-output replacement expressions
- gsub over 10,000 matches without StackOverflowError`n
Verification:
- mvn -pl jackson-jq -Dtest=SubImplFunctionTest test`n
Note: I did not rely on the full module test suite on Windows because existing test infrastructure hits unrelated Windows path/cache issues (/C:/... path parsing and RocksDB cache path behavior).