### PR TITLE
Support "if" expressions without "else" branch

### DIFF
--- a/jackson-jq/src/main/javacc/json-query.jj
+++ b/jackson-jq/src/main/javacc/json-query.jj
@@ -775,7 +775,7 @@ Expression ConditionalExpression():
 	Expression tmpPred;
 	Expression tmpExpr;
 	final List<Pair<Expression, Expression>> switches = new ArrayList<Pair<Expression, Expression>>();
-	final Expression otherwise;
+	Expression otherwise = new ThisObject();
 }
 {
 	<KEYWORD_IF>
@@ -790,8 +790,10 @@ Expression ConditionalExpression():
 		tmpExpr = Expression()
 		{ switches.add(Pair.of(tmpPred, tmpExpr)); }
 	)*
-	<KEYWORD_ELSE>
-	otherwise = Expression()
+	(
+    	<KEYWORD_ELSE>
+    	otherwise = Expression()
+    )?
 	<KEYWORD_END>
 	{
 		return new Conditional(switches, otherwise);

--- a/jackson-jq/src/test/resources/tests/constructs/if.yaml
+++ b/jackson-jq/src/test/resources/tests/constructs/if.yaml
@@ -1,0 +1,14 @@
+- q: 'if true then 1 else 2 end'
+  out:
+  - 1
+- q: 'if false then 1 end'
+  in: 2
+  out:
+  - 2
+- q: 'if false then 1 elif false then 2 else 3 end'
+  out:
+  - 3
+- q: 'if false then 1 elif false then 2 end'
+  in: 3
+  out:
+  - 3


### PR DESCRIPTION
Support queries that contain `if` expressions without an `else` branch, e.g. `if false then 1 end`.

If the `else` branch absent, then it is the same as `.` as specified in the documentation of [if-then-else-end](https://jqlang.org/manual/#if-then-else-end).

This PR fixes #542.