### PR TITLE
Upgrade jandex-maven-plugin to 3.x for Quarkus 3.x+ compatibility

### DIFF
--- a/jackson-jq-extra/pom.xml
+++ b/jackson-jq-extra/pom.xml
@@ -36,7 +36,7 @@
 				</configuration>
 			</plugin>
 			<plugin>
-				<groupId>org.jboss.jandex</groupId>
+				<groupId>io.smallrye</groupId>
 				<artifactId>jandex-maven-plugin</artifactId>
 				<executions>
 					<execution>

--- a/jackson-jq/pom.xml
+++ b/jackson-jq/pom.xml
@@ -124,7 +124,7 @@
 				</configuration>
 			</plugin>
 			<plugin>
-				<groupId>org.jboss.jandex</groupId>
+				<groupId>io.smallrye</groupId>
 				<artifactId>jandex-maven-plugin</artifactId>
 				<executions>
 					<execution>

--- a/pom.xml
+++ b/pom.xml
@@ -295,9 +295,9 @@
 					<version>3.2.8</version>
 				</plugin>
 				<plugin>
-					<groupId>org.jboss.jandex</groupId>
+					<groupId>io.smallrye</groupId>
 					<artifactId>jandex-maven-plugin</artifactId>
-					<version>1.2.3</version>
+					<version>3.2.3</version>
 				</plugin>
 			</plugins>
 		</pluginManagement>


### PR DESCRIPTION
## Summary

Upgrades the `jandex-maven-plugin` from version 1.2.3 (org.jboss.jandex) to version 3.2.3 (io.smallrye) to generate Jandex 3.x format indexes.

## Motivation

The current Jandex Maven Plugin version (1.2.3) generates Jandex 2.x format indexes (version 10), which causes warnings when used with Quarkus 3.x+ that requires Jandex 3.x:

```
[WARNING] [io.quarkus.deployment.index] Reindexing /path/to/jackson-jq-1.6.2.jar, at least Jandex 3.0 must be used to index an application dependency (index version is 10)
[WARNING] [io.quarkus.deployment.index] Reindexing /path/to/jackson-jq-extra-1.6.2.jar, at least Jandex 3.0 must be used to index an application dependency (index version is 10)
```

While Quarkus automatically reindexes these dependencies at build time (so functionality isn't affected), upgrading to `jandex-maven-plugin` 3.x eliminates these warnings and improves build performance by avoiding unnecessary reindexing.

## Changes

- ✅ Updated parent POM `pluginManagement`: `io.smallrye:jandex-maven-plugin:3.2.3`
- ✅ Updated `jackson-jq` module to use new groupId
- ✅ Updated `jackson-jq-extra` module to use new groupId
- ✅ Verified build succeeds with new plugin
- ✅ Confirmed generated indexes use Jandex 3.x format

## Benefits

- ✅ Eliminates Quarkus 3.x+ reindexing warnings
- ✅ Improves build performance for downstream projects
- ✅ Future-proof for Quarkus 4.x and newer Java frameworks
- ✅ No breaking changes (Jandex 3.x indexes are backward compatible for reading)

## Testing

Verified that:
1. Build completes successfully: `mvn clean compile -pl jackson-jq,jackson-jq-extra -am`
2. Jandex plugin executes: `jandex:3.2.3:jandex (make-index)`
3. Indexes are generated in `META-INF/jandex.idx`
4. Index format is Jandex 3.x (binary header verification)

## References

- Jandex 3.x releases: https://github.com/smallrye/jandex/releases
- Original Jandex indexing PR: #196
- SmallRye Jandex Maven Plugin: https://github.com/smallrye/jandex-maven-plugin